### PR TITLE
Avoid unwrap during key creation

### DIFF
--- a/benches/vart_bench.rs
+++ b/benches/vart_bench.rs
@@ -5,13 +5,13 @@ use rand::prelude::SliceRandom;
 use rand::{thread_rng, Rng};
 
 use vart::art::Tree;
-use vart::FixedKey;
+use vart::FixedSizeKey;
 
 pub fn seq_insert(c: &mut Criterion) {
     let mut group = c.benchmark_group("seq_insert");
     group.throughput(Throughput::Elements(1));
     group.bench_function("seq_insert", |b| {
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         let mut key = 0u64;
         b.iter(|| {
             tree.insert(&key.into(), key, 0, 0);
@@ -29,7 +29,7 @@ pub fn rand_insert(c: &mut Criterion) {
     let keys = gen_keys(3, 2, 3);
 
     group.bench_function("art", |b| {
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         let mut rng = thread_rng();
         b.iter(|| {
             let key = &keys[rng.gen_range(0..keys.len())];
@@ -44,7 +44,7 @@ pub fn seq_delete(c: &mut Criterion) {
     let mut group = c.benchmark_group("seq_delete");
     group.throughput(Throughput::Elements(1));
     group.bench_function("art", |b| {
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         b.iter_custom(|iters| {
             for i in 0..iters {
                 tree.insert(&i.into(), i, 0, 0);
@@ -66,7 +66,7 @@ pub fn rand_delete(c: &mut Criterion) {
 
     group.throughput(Throughput::Elements(1));
     group.bench_function("art", |b| {
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         let mut rng = thread_rng();
         for key in &keys {
             tree.insert(&key.into(), key, 0, 0);
@@ -86,7 +86,7 @@ pub fn rand_get(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     {
         let size = 1_000_000;
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         for i in 0..size as u64 {
             tree.insert(&i.into(), i, 0, 0).unwrap();
         }
@@ -108,7 +108,7 @@ pub fn rand_get_str(c: &mut Criterion) {
 
     {
         let size = 1_000_000;
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         for (i, key) in keys.iter().enumerate() {
             tree.insert(&key.into(), i, 0, 0).unwrap();
         }
@@ -130,7 +130,7 @@ pub fn seq_get(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     {
         let size = 1_000_000;
-        let mut tree = Tree::<FixedKey<16>, _>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, _>::new();
         for i in 0..size as u64 {
             tree.insert(&i.into(), i, 0, 0).unwrap();
         }

--- a/src/art.rs
+++ b/src/art.rs
@@ -1303,7 +1303,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 #[cfg(test)]
 mod tests {
     use super::{Tree, KV};
-    use crate::{FixedKey, VariableKey};
+    use crate::{FixedSizeKey, VariableSizeKey};
     use std::str::FromStr;
 
     use std::fs::File;
@@ -1318,26 +1318,26 @@ mod tests {
 
     #[test]
     fn insert_search_delete_words() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
         let file_path = "testdata/words.txt";
 
         if let Ok(words) = read_words_from_file(file_path) {
             // Insertion phase
             for word in &words {
-                let key = &VariableKey::from_str(word).unwrap();
+                let key = &VariableSizeKey::from_str(word).unwrap();
                 tree.insert(key, 1, 0, 0);
             }
 
             // Search phase
             for word in &words {
-                let key = VariableKey::from_str(word).unwrap();
+                let key = VariableSizeKey::from_str(word).unwrap();
                 let (_, val, _, _) = tree.get(&key, 0).unwrap();
                 assert_eq!(val, 1);
             }
 
             // Deletion phase
             for word in &words {
-                let key = VariableKey::from_str(word).unwrap();
+                let key = VariableSizeKey::from_str(word).unwrap();
                 assert!(tree.remove(&key).unwrap());
             }
         } else if let Err(err) = read_words_from_file(file_path) {
@@ -1349,7 +1349,7 @@ mod tests {
 
     #[test]
     fn string_insert_delete() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion phase
         let insert_words = [
@@ -1357,18 +1357,20 @@ mod tests {
         ];
 
         for word in &insert_words {
-            tree.insert(&VariableKey::from_str(word).unwrap(), 1, 0, 0);
+            tree.insert(&VariableSizeKey::from_str(word).unwrap(), 1, 0, 0);
         }
 
         // Deletion phase
         for word in &insert_words {
-            assert!(tree.remove(&VariableKey::from_str(word).unwrap()).unwrap());
+            assert!(tree
+                .remove(&VariableSizeKey::from_str(word).unwrap())
+                .unwrap());
         }
     }
 
     #[test]
     fn string_long() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion phase
         let words_to_insert = [
@@ -1378,22 +1380,24 @@ mod tests {
         ];
 
         for (word, val) in &words_to_insert {
-            tree.insert(&VariableKey::from_str(word).unwrap(), *val, 0, 0);
+            tree.insert(&VariableSizeKey::from_str(word).unwrap(), *val, 0, 0);
         }
 
         // Verification phase
         for (word, expected_val) in &words_to_insert {
-            let (_, val, _, _) = tree.get(&VariableKey::from_str(word).unwrap(), 0).unwrap();
+            let (_, val, _, _) = tree
+                .get(&VariableSizeKey::from_str(word).unwrap(), 0)
+                .unwrap();
             assert_eq!(val, *expected_val);
         }
     }
 
     #[test]
     fn root_set_get() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion phase
-        let key = VariableKey::from_str("abc").unwrap();
+        let key = VariableSizeKey::from_str("abc").unwrap();
         let value = 1;
         tree.insert(&key, value, 0, 0);
 
@@ -1404,10 +1408,10 @@ mod tests {
 
     #[test]
     fn string_duplicate_insert() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // First insertion
-        let key = VariableKey::from_str("abc").unwrap();
+        let key = VariableSizeKey::from_str("abc").unwrap();
         let value = 1;
         let result = tree.insert(&key, value, 0, 0).expect("Failed to insert");
         assert!(result.is_none());
@@ -1420,10 +1424,10 @@ mod tests {
     // Inserting a single value into the tree and removing it should result in a nil tree root.
     #[test]
     fn insert_and_remove() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
-        let key = VariableKey::from_str("test").unwrap();
+        let key = VariableSizeKey::from_str("test").unwrap();
         let value = 1;
         tree.insert(&key, value, 0, 0);
 
@@ -1436,10 +1440,10 @@ mod tests {
 
     #[test]
     fn inserting_keys_with_common_prefix() {
-        let key1 = VariableKey::from_str("foo").unwrap();
-        let key2 = VariableKey::from_str("foo2").unwrap();
+        let key1 = VariableSizeKey::from_str("foo").unwrap();
+        let key2 = VariableSizeKey::from_str("foo2").unwrap();
 
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         tree.insert(&key1, 1, 0, 0);
@@ -1460,10 +1464,10 @@ mod tests {
     // should result in a tree root of type twig
     #[test]
     fn insert2_and_remove1_and_root_should_be_node1() {
-        let key1 = VariableKey::from_str("test1").unwrap();
-        let key2 = VariableKey::from_str("test2").unwrap();
+        let key1 = VariableSizeKey::from_str("test1").unwrap();
+        let key2 = VariableSizeKey::from_str("test2").unwrap();
 
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         tree.insert(&key1, 1, 0, 0);
@@ -1486,10 +1490,10 @@ mod tests {
     // // successfully collapsing into a twig and then nil upon successive removals
     // #[test]
     // fn insert2_and_remove2_and_root_should_be_nil() {
-    //     let key1 = &VariableKey::from_str("test1");
-    //     let key2 = &VariableKey::from_str("test2");
+    //     let key1 = &VariableSizeKey::from_str("test1");
+    //     let key2 = &VariableSizeKey::from_str("test2");
 
-    //     let mut tree = Tree::<VariableKey, i32>::new();
+    //     let mut tree = Tree::<VariableSizeKey, i32>::new();
     //     tree.insert(key1, 1, 0, 0);
     //     tree.insert(key2, 1, 0);
 
@@ -1505,16 +1509,16 @@ mod tests {
     // successfully collapsing into a NODE4 upon successive removals
     #[test]
     fn insert5_and_remove1_and_root_should_be_node4() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         for i in 0..5u32 {
-            let key = VariableKey::from_slice(&i.to_be_bytes());
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
             tree.insert(&key, 1, 0, 0);
         }
 
         // Removal
-        let key_to_remove = VariableKey::from_slice(&1u32.to_be_bytes());
+        let key_to_remove = VariableSizeKey::from_slice(&1u32.to_be_bytes());
         assert!(tree.remove(&key_to_remove).unwrap());
 
         // Root verification
@@ -1532,15 +1536,15 @@ mod tests {
     //     // successfully collapsing into a NODE4, twig, then nil
     //     #[test]
     //     fn insert5_and_remove5_and_root_should_be_nil() {
-    //         let mut tree = Tree::<VariableKey, i32>::new();
+    //         let mut tree = Tree::<VariableSizeKey, i32>::new();
 
     //         for i in 0..5u32 {
-    //             let key = &VariableKey::from_slice(&i.to_be_bytes());
+    //             let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
     //             tree.insert(key, 1);
     //         }
 
     //         for i in 0..5u32 {
-    //             let key = &VariableKey::from_slice(&i.to_be_bytes());
+    //             let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
     //             tree.remove(key);
     //         }
 
@@ -1553,16 +1557,16 @@ mod tests {
     // successfully collapsing into a NODE16
     #[test]
     fn insert17_and_remove1_and_root_should_be_node16() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         for i in 0..17u32 {
-            let key = VariableKey::from_slice(&i.to_be_bytes());
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
             tree.insert(&key, 1, 0, 0);
         }
 
         // Removal
-        let key_to_remove = VariableKey::from_slice(&2u32.to_be_bytes());
+        let key_to_remove = VariableSizeKey::from_slice(&2u32.to_be_bytes());
         assert!(tree.remove(&key_to_remove).unwrap());
 
         // Root verification
@@ -1576,11 +1580,11 @@ mod tests {
 
     #[test]
     fn insert17_and_root_should_be_node48() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         for i in 0..17u32 {
-            let key = VariableKey::from_slice(&i.to_be_bytes());
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
             tree.insert(&key, 1, 0, 0);
         }
 
@@ -1599,15 +1603,15 @@ mod tests {
     // // successfully collapsing into a NODE16, NODE4, twig, and then nil
     // #[test]
     // fn insert17_and_remove17_and_root_should_be_nil() {
-    //     let mut tree = Tree::<VariableKey, i32>::new();
+    //     let mut tree = Tree::<VariableSizeKey, i32>::new();
 
     //     for i in 0..17u32 {
-    //         let key = VariableKey::from_slice(&i.to_be_bytes());
+    //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
     //         tree.insert(&key, 1);
     //     }
 
     //     for i in 0..17u32 {
-    //         let key = VariableKey::from_slice(&i.to_be_bytes());
+    //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
     //         tree.remove(&key);
     //     }
 
@@ -1620,16 +1624,16 @@ mod tests {
     // successfully collapasing into a NODE48
     #[test]
     fn insert49_and_remove1_and_root_should_be_node48() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         for i in 0..49u32 {
-            let key = VariableKey::from_slice(&i.to_be_bytes());
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
             tree.insert(&key, 1, 0, 0);
         }
 
         // Removal
-        let key_to_remove = VariableKey::from_slice(&2u32.to_be_bytes());
+        let key_to_remove = VariableSizeKey::from_slice(&2u32.to_be_bytes());
         assert!(tree.remove(&key_to_remove).unwrap());
 
         // Root verification
@@ -1643,11 +1647,11 @@ mod tests {
 
     #[test]
     fn insert49_and_root_should_be_node248() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertion
         for i in 0..49u32 {
-            let key = VariableKey::from_slice(&i.to_be_bytes());
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
             tree.insert(&key, 1, 0, 0);
         }
 
@@ -1666,15 +1670,15 @@ mod tests {
     //     // // successfully collapsing into a Node48, Node16, Node4, twig, and finally nil
     //     // #[test]
     //     // fn insert49_and_remove49_and_root_should_be_nil() {
-    //     //     let mut tree = Tree::<VariableKey, i32>::new();
+    //     //     let mut tree = Tree::<VariableSizeKey, i32>::new();
 
     //     //     for i in 0..49u32 {
-    //     //         let key = &VariableKey::from_slice(&i.to_be_bytes());
+    //     //         let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
     //     //         tree.insert(key, 1);
     //     //     }
 
     //     //     for i in 0..49u32 {
-    //     //         let key = VariableKey::from_slice(&i.to_be_bytes());
+    //     //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
     //     //         assert_eq!(tree.remove(&key), true);
     //     //     }
 
@@ -1689,7 +1693,7 @@ mod tests {
 
     #[test]
     fn timed_insertion() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
 
         let kvts = vec![
             KVT {
@@ -1726,14 +1730,14 @@ mod tests {
                 kvt.version
             };
             assert!(tree
-                .insert(&VariableKey::from(kvt.k.clone()), 1, ts, 0)
+                .insert(&VariableSizeKey::from(kvt.k.clone()), 1, ts, 0)
                 .is_ok());
         }
 
         // Verification
         let mut curr_version = 1;
         for kvt in &kvts {
-            let key = VariableKey::from(kvt.k.clone());
+            let key = VariableSizeKey::from(kvt.k.clone());
             let (_, val, version, _ts) = tree.get(&key, 0).unwrap();
             assert_eq!(val, 1);
 
@@ -1752,9 +1756,9 @@ mod tests {
 
     #[test]
     fn timed_insertion_update_same_key() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
 
-        let key1 = &VariableKey::from_str("key_1").unwrap();
+        let key1 = &VariableSizeKey::from_str("key_1").unwrap();
 
         // insert key1 with version 0
         assert!(tree.insert(key1, 1, 0, 1).is_ok());
@@ -1783,10 +1787,10 @@ mod tests {
 
     #[test]
     fn timed_insertion_update_non_increasing_version() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
 
-        let key1 = VariableKey::from_str("key_1").unwrap();
-        let key2 = VariableKey::from_str("key_2").unwrap();
+        let key1 = VariableSizeKey::from_str("key_1").unwrap();
+        let key2 = VariableSizeKey::from_str("key_2").unwrap();
 
         // Initial insertion
         assert!(tree.insert(&key1, 1, 10, 0).is_ok());
@@ -1816,10 +1820,10 @@ mod tests {
 
     #[test]
     fn timed_insertion_update_equal_to_root_version() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
 
-        let key1 = VariableKey::from_str("key_1").unwrap();
-        let key2 = VariableKey::from_str("key_2").unwrap();
+        let key1 = VariableSizeKey::from_str("key_1").unwrap();
+        let key2 = VariableSizeKey::from_str("key_2").unwrap();
 
         // Initial insertion
         assert!(tree.insert(&key1, 1, 10, 0).is_ok());
@@ -1831,9 +1835,9 @@ mod tests {
 
     #[test]
     fn timed_deletion_check_root_ts() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
-        let key1 = VariableKey::from_str("key_1").unwrap();
-        let key2 = VariableKey::from_str("key_2").unwrap();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
+        let key1 = VariableSizeKey::from_str("key_1").unwrap();
+        let key2 = VariableSizeKey::from_str("key_2").unwrap();
 
         // Initial insertions
         assert!(tree.insert(&key1, 1, 0, 0).is_ok());
@@ -1861,11 +1865,11 @@ mod tests {
 
     #[test]
     fn iter_seq_u16() {
-        let mut tree = Tree::<FixedKey<16>, u16>::new();
+        let mut tree = Tree::<FixedSizeKey<16>, u16>::new();
 
         // Insertion
         for i in 0..u16::MAX {
-            let key: FixedKey<16> = i.into();
+            let key: FixedSizeKey<16> = i.into();
             tree.insert(&key, i, 0, i as u64);
         }
 
@@ -1889,11 +1893,11 @@ mod tests {
 
     #[test]
     fn iter_seq_u8() {
-        let mut tree: Tree<FixedKey<32>, u8> = Tree::<FixedKey<32>, u8>::new();
+        let mut tree: Tree<FixedSizeKey<32>, u8> = Tree::<FixedSizeKey<32>, u8>::new();
 
         // Insertion
         for i in 0..u8::MAX {
-            let key: FixedKey<32> = i.into();
+            let key: FixedSizeKey<32> = i.into();
             tree.insert(&key, i, 0, 0);
         }
 
@@ -1915,18 +1919,18 @@ mod tests {
 
     #[test]
     fn range_seq_u8() {
-        let mut tree: Tree<FixedKey<8>, u8> = Tree::<FixedKey<8>, u8>::new();
+        let mut tree: Tree<FixedSizeKey<8>, u8> = Tree::<FixedSizeKey<8>, u8>::new();
 
         let max = u8::MAX;
         // Insertion
         for i in 0..=max {
-            let key: FixedKey<8> = i.into();
+            let key: FixedSizeKey<8> = i.into();
             tree.insert(&key, i, 0, 0);
         }
 
         // Test inclusive range
-        let start_key: FixedKey<8> = 5u8.into();
-        let end_key: FixedKey<8> = max.into();
+        let start_key: FixedSizeKey<8> = 5u8.into();
+        let end_key: FixedSizeKey<8> = max.into();
         let mut len = 0usize;
         for _ in tree.range(start_key..=end_key) {
             len += 1;
@@ -1934,8 +1938,8 @@ mod tests {
         assert_eq!(len, max as usize - 4);
 
         // Test exclusive range
-        let start_key: FixedKey<8> = 5u8.into();
-        let end_key: FixedKey<8> = max.into();
+        let start_key: FixedSizeKey<8> = 5u8.into();
+        let end_key: FixedSizeKey<8> = max.into();
         let mut len = 0usize;
         for _ in tree.range(start_key..end_key) {
             len += 1;
@@ -1943,8 +1947,8 @@ mod tests {
         assert_eq!(len, max as usize - 5);
 
         // Test range with different start and end keys
-        let start_key: FixedKey<8> = 3u8.into();
-        let end_key: FixedKey<8> = 7u8.into();
+        let start_key: FixedSizeKey<8> = 3u8.into();
+        let end_key: FixedSizeKey<8> = 7u8.into();
         let mut len = 0usize;
         for _ in tree.range(start_key..=end_key) {
             len += 1;
@@ -1952,8 +1956,8 @@ mod tests {
         assert_eq!(len, 5);
 
         // Test range with all keys
-        let start_key: FixedKey<8> = 0u8.into();
-        let end_key: FixedKey<8> = max.into();
+        let start_key: FixedSizeKey<8> = 0u8.into();
+        let end_key: FixedSizeKey<8> = max.into();
         let mut len = 0usize;
         for _ in tree.range(start_key..=end_key) {
             len += 1;
@@ -1963,18 +1967,18 @@ mod tests {
 
     #[test]
     fn range_seq_u16() {
-        let mut tree: Tree<FixedKey<16>, u16> = Tree::<FixedKey<16>, u16>::new();
+        let mut tree: Tree<FixedSizeKey<16>, u16> = Tree::<FixedSizeKey<16>, u16>::new();
 
         let max = u16::MAX;
         // Insertion
         for i in 0..=max {
-            let key: FixedKey<16> = i.into();
+            let key: FixedSizeKey<16> = i.into();
             tree.insert(&key, i, 0, 0);
         }
 
         let mut len = 0usize;
-        let start_key: FixedKey<16> = 0u8.into();
-        let end_key: FixedKey<16> = max.into();
+        let start_key: FixedSizeKey<16> = 0u8.into();
+        let end_key: FixedSizeKey<16> = max.into();
 
         for _ in tree.range(start_key..=end_key) {
             len += 1;
@@ -1984,11 +1988,11 @@ mod tests {
 
     #[test]
     fn same_key_with_versions() {
-        let mut tree = Tree::<VariableKey, i32>::new();
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
         // Insertions
-        let key1 = VariableKey::from_str("abc").unwrap();
-        let key2 = VariableKey::from_str("efg").unwrap();
+        let key1 = VariableSizeKey::from_str("abc").unwrap();
+        let key2 = VariableSizeKey::from_str("efg").unwrap();
         tree.insert(&key1, 1, 0, 0);
         tree.insert(&key1, 2, 10, 0);
         tree.insert(&key2, 3, 11, 0);
@@ -2012,42 +2016,42 @@ mod tests {
 
     #[test]
     fn bulk_insert() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
         let curr_version = tree.version();
         // Create a vector of KV<P, V>
         let kv_pairs = vec![
             KV {
-                key: VariableKey::from_str("key_1").unwrap(),
+                key: VariableSizeKey::from_str("key_1").unwrap(),
                 value: 1,
                 version: 0,
                 ts: 0,
             },
             KV {
-                key: VariableKey::from_str("key_2").unwrap(),
+                key: VariableSizeKey::from_str("key_2").unwrap(),
                 value: 1,
                 version: 2,
                 ts: 0,
             },
             KV {
-                key: VariableKey::from_str("key_3").unwrap(),
+                key: VariableSizeKey::from_str("key_3").unwrap(),
                 value: 1,
                 version: curr_version + 1,
                 ts: 0,
             },
             KV {
-                key: VariableKey::from_str("key_4").unwrap(),
+                key: VariableSizeKey::from_str("key_4").unwrap(),
                 value: 1,
                 version: curr_version + 1,
                 ts: 0,
             },
             KV {
-                key: VariableKey::from_str("key_5").unwrap(),
+                key: VariableSizeKey::from_str("key_5").unwrap(),
                 value: 1,
                 version: curr_version + 2,
                 ts: 0,
             },
             KV {
-                key: VariableKey::from_str("key_6").unwrap(),
+                key: VariableSizeKey::from_str("key_6").unwrap(),
                 value: 1,
                 version: 0,
                 ts: 0,
@@ -2067,7 +2071,7 @@ mod tests {
             }
         }
         assert!(tree
-            .insert(&VariableKey::from_str("key_7").unwrap(), 1, 0, 0)
+            .insert(&VariableSizeKey::from_str("key_7").unwrap(), 1, 0, 0)
             .is_ok());
         assert!(tree.version() == curr_version + 3);
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -41,7 +41,7 @@ impl<P: KeyTrait, V: Clone> IterationPointer<P, V> {
     where
         R: RangeBounds<P> + 'a,
     {
-        return Range::new(Some(&self.root), range);
+        Range::new(Some(&self.root), range)
     }
 }
 
@@ -89,16 +89,15 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iter<'a, P, V> {
     /// * `node` - An optional reference to the root node of the Trie.
     ///
     pub(crate) fn new(node: Option<&'a Arc<Node<P, V>>>) -> Self {
-        if let Some(node) = node {
-            Self {
+        match node {
+            Some(node) => Self {
                 inner: Box::new(IterState::new(node)),
                 _marker: Default::default(),
-            }
-        } else {
-            Self {
+            },
+            None => Self {
                 inner: Box::new(std::iter::empty()),
                 _marker: Default::default(),
-            }
+            },
         }
     }
 }
@@ -176,7 +175,7 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iterator for IterState<'a, P, V> {
             let e = node.next();
             match e {
                 None => {
-                    self.iters.pop().unwrap();
+                    self.iters.pop();
                 }
                 Some(other) => {
                     if let NodeType::Twig(twig) = &other.1.node_type {
@@ -263,7 +262,7 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
                     }
                 }
                 None => {
-                    self.forward.iters.pop().unwrap();
+                    self.forward.iters.pop();
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,11 @@ pub mod node;
 pub mod snapshot;
 
 use std::cmp::{Ord, Ordering, PartialOrd};
+use std::error::Error;
+use std::fmt;
 use std::fmt::Debug;
+use std::mem::MaybeUninit;
+use std::str::FromStr;
 
 // "Partial" in the Adaptive Radix Tree paper refers to "partial keys", a technique employed
 // for prefix compression in this data structure. Instead of storing entire keys in the nodes,
@@ -73,7 +77,7 @@ impl<const SIZE: usize> Ord for FixedKey<SIZE> {
 impl<const SIZE: usize> FixedKey<SIZE> {
     // Create new instance with data ending in zero byte
     pub fn create_key(src: &[u8]) -> Self {
-        assert!(src.len() < SIZE);
+        debug_assert!(src.len() < SIZE);
         let mut content = [0; SIZE];
         content[..src.len()].copy_from_slice(src);
         content[src.len()] = 0;
@@ -85,22 +89,12 @@ impl<const SIZE: usize> FixedKey<SIZE> {
 
     // Create new instance from slice
     pub fn from_slice(src: &[u8]) -> Self {
-        assert!(src.len() <= SIZE);
+        debug_assert!(src.len() <= SIZE);
         let mut content = [0; SIZE];
         content[..src.len()].copy_from_slice(src);
         Self {
             content,
             len: src.len(),
-        }
-    }
-
-    pub fn from_str(s: &str) -> Self {
-        assert!(s.len() < SIZE, "data length is greater than array length");
-        let mut arr = [0; SIZE];
-        arr[..s.len()].copy_from_slice(s.as_bytes());
-        Self {
-            content: arr,
-            len: s.len() + 1,
         }
     }
 
@@ -155,6 +149,22 @@ impl<const SIZE: usize> Key for FixedKey<SIZE> {
     }
 }
 
+impl<const SIZE: usize> FromStr for FixedKey<SIZE> {
+    type Err = TrieError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() >= SIZE {
+            return Err(TrieError::FixedKeyLengthExceeded);
+        }
+        let mut arr = [0; SIZE];
+        arr[..s.len()].copy_from_slice(s.as_bytes());
+        Ok(Self {
+            content: arr,
+            len: s.len() + 1,
+        })
+    }
+}
+
 impl<const SIZE: usize> From<&[u8]> for FixedKey<SIZE> {
     fn from(src: &[u8]) -> Self {
         Self::from_slice(src)
@@ -181,7 +191,7 @@ impl<const N: usize> From<u64> for FixedKey<N> {
 
 impl<const N: usize> From<&str> for FixedKey<N> {
     fn from(data: &str) -> Self {
-        Self::from_str(data)
+        Self::from_str(data).unwrap()
     }
 }
 
@@ -234,13 +244,6 @@ impl VariableKey {
         Self { data }
     }
 
-    pub fn from_str(s: &str) -> Self {
-        let mut data = Vec::with_capacity(s.len() + 1);
-        data.extend_from_slice(s.as_bytes());
-        data.push(0);
-        Self { data }
-    }
-
     pub fn from(data: Vec<u8>) -> Self {
         Self { data }
     }
@@ -250,6 +253,17 @@ impl VariableKey {
         data.extend_from_slice(src);
         data.push(0);
         Self { data }
+    }
+}
+
+impl FromStr for VariableKey {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut data = Vec::with_capacity(s.len() + 1);
+        data.extend_from_slice(s.as_bytes());
+        data.push(0);
+        Ok(Self { data })
     }
 }
 
@@ -297,157 +311,282 @@ impl Key for VariableKey {
 }
 
 /*
-    Sparse Array implementation
+    BitSet implementation
 */
 
-/// A struct `SparseVector` is a generic wrapper over a Vector that can store elements of type `X`.
-/// It has a pre-defined constant capacity `WIDTH`. The elements are stored in a `Vec<Option<X>>`,
-/// allowing for storage to be dynamically allocated and deallocated.
 #[derive(Clone)]
-pub struct SparseVector<X, const WIDTH: usize> {
-    storage: Vec<Option<X>>,
+pub struct BitSet<const SIZE: usize> {
+    bits: [bool; SIZE],
 }
 
-/// This is an implementation of the Default trait for SparseVector. It simply calls the `new` function.
-impl<X, const WIDTH: usize> Default for SparseVector<X, WIDTH> {
+impl<const SIZE: usize> BitSet<SIZE> {
+    pub fn new() -> Self {
+        Self {
+            bits: [false; SIZE],
+        }
+    }
+
+    pub fn first_empty(&self) -> Option<usize> {
+        self.bits.iter().position(|&bit| !bit)
+    }
+
+    pub fn first_set(&self) -> Option<usize> {
+        self.bits.iter().position(|&bit| bit)
+    }
+
+    pub fn set(&mut self, pos: usize) {
+        if pos < self.bits.len() {
+            self.bits[pos] = true;
+        }
+    }
+
+    pub fn unset(&mut self, pos: usize) {
+        if pos < self.bits.len() {
+            self.bits[pos] = false;
+        }
+    }
+
+    pub fn check(&self, pos: usize) -> bool {
+        pos < self.bits.len() && self.bits[pos]
+    }
+
+    pub fn clear(&mut self) {
+        for bit in &mut self.bits {
+            *bit = false;
+        }
+    }
+
+    pub fn last(&self) -> Option<usize> {
+        self.bits.iter().rposition(|&bit| bit)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bits.iter().all(|&bit| !bit)
+    }
+
+    pub fn size(&self) -> usize {
+        self.bits.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.bits.len()
+    }
+}
+
+/// A struct `BitArray` is a generic wrapper over an array that can store elements of type `X`.
+pub struct BitArray<X, const WIDTH: usize> {
+    items: Box<[MaybeUninit<X>; WIDTH]>,
+    bits: BitSet<WIDTH>,
+}
+/// This is an implementation of the Default trait for BitArray. It simply calls the `new` function.
+impl<X, const WIDTH: usize> Default for BitArray<X, WIDTH> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<X, const WIDTH: usize> SparseVector<X, WIDTH> {
-    /// This function constructs a new SparseVector with a `WIDTH` number of `Option<X>` elements.
+impl<X, const WIDTH: usize> BitArray<X, WIDTH> {
+    /// This function constructs a new BitArray with a `WIDTH` number of `Option<X>` elements.
     pub fn new() -> Self {
         Self {
-            storage: Vec::with_capacity(WIDTH),
+            items: Box::new(unsafe { MaybeUninit::uninit().assume_init() }),
+            bits: BitSet::new(),
         }
     }
 
-    /// This function adds a new element `x` to the SparseVector at the first available position. If the
-    /// SparseVector is full, it automatically resizes to make room for more elements. It returns the
-    /// position where the element was inserted.
-    pub fn push(&mut self, x: X) -> usize {
-        let pos = self.first_free_pos();
-        self.storage[pos] = Some(x);
-        pos
-    }
-
-    /// This function removes and returns the last element in the SparseVector if it exists.
-    pub fn pop(&mut self) -> Option<X> {
-        self.last_used_pos()
-            .and_then(|pos| self.storage[pos].take())
-    }
-
-    /// This function returns a reference to the last element in the SparseVector, if it exists.
-    pub fn last(&self) -> Option<&X> {
-        self.last_used_pos()
-            .and_then(|pos| self.storage[pos].as_ref())
-    }
-
-    /// This function returns the position of the last used (non-None) element in the SparseVector, if it exists.
-    #[inline]
-    pub fn last_used_pos(&self) -> Option<usize> {
-        self.storage.iter().rposition(Option::is_some)
-    }
-
-    /// This function finds the position of the first free (None) slot in the SparseVector. If all slots are filled,
-    /// it expands the SparseVector and returns the position of the new slot.
-    #[inline]
-    pub fn first_free_pos(&mut self) -> usize {
-        let pos = self.storage.iter().position(|x| x.is_none());
-        match pos {
-            Some(p) => p,
-            None => {
-                // No free position was found, so we add a new one.
-                self.storage.push(None);
-                self.storage.len() - 1
+    pub fn push(&mut self, x: X) -> Option<usize> {
+        if let Some(pos) = self.bits.first_empty() {
+            self.bits.set(pos);
+            unsafe {
+                self.items[pos].as_mut_ptr().write(x);
             }
-        }
-    }
-
-    /// This function returns an `Option` containing a reference to the element at the given position, if it exists.
-    #[inline]
-    pub fn get(&self, pos: usize) -> Option<&X> {
-        self.storage.get(pos).and_then(Option::as_ref)
-    }
-
-    /// This function returns an `Option` containing a mutable reference to the element at the given position, if it exists.
-    #[inline]
-    pub fn get_mut(&mut self, pos: usize) -> Option<&mut X> {
-        self.storage.get_mut(pos).and_then(Option::as_mut)
-    }
-
-    /// This function sets the element at the given position to the provided value. If the position is out of bounds,
-    /// it automatically resizes the SparseVector to make room for more elements.
-    #[inline]
-    pub fn set(&mut self, pos: usize, x: X) {
-        if pos < self.storage.len() {
-            self.storage[pos] = Some(x);
+            Some(pos)
         } else {
-            self.storage.resize_with(pos + 1, || None);
-            self.storage[pos] = Some(x);
+            None
         }
     }
 
-    /// This function removes the element at the given position from the SparseVector, returning it if it exists.
+    pub fn pop(&mut self) -> Option<X> {
+        if let Some(pos) = self.bits.last() {
+            self.bits.unset(pos);
+            let old = std::mem::replace(&mut self.items[pos], MaybeUninit::uninit());
+            Some(unsafe { old.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    pub fn last(&self) -> Option<&X> {
+        if let Some(pos) = self.bits.last() {
+            unsafe { Some(self.items[pos].assume_init_ref()) }
+        } else {
+            None
+        }
+    }
+
+    pub fn get(&self, pos: usize) -> Option<&X> {
+        if self.bits.check(pos) {
+            unsafe { Some(self.items[pos].assume_init_ref()) }
+        } else {
+            None
+        }
+    }
+
+    pub fn get_mut(&mut self, pos: usize) -> Option<&mut X> {
+        if self.bits.check(pos) {
+            unsafe { Some(self.items[pos].assume_init_mut()) }
+        } else {
+            None
+        }
+    }
+
+    pub fn set(&mut self, pos: usize, x: X) {
+        if pos < self.items.len() {
+            unsafe {
+                self.items[pos].as_mut_ptr().write(x);
+            };
+            self.bits.set(pos);
+        }
+    }
+
     #[inline]
     pub fn erase(&mut self, pos: usize) -> Option<X> {
-        self.storage[pos].take()
+        assert!(pos < WIDTH);
+        if self.bits.check(pos) {
+            let old = std::mem::replace(&mut self.items[pos], MaybeUninit::uninit());
+            self.bits.unset(pos);
+            Some(unsafe { old.assume_init() })
+        } else {
+            None
+        }
     }
 
-    /// This function clears the SparseVector, removing all elements.
     pub fn clear(&mut self) {
-        self.storage.clear();
+        for i in 0..WIDTH {
+            if self.bits.check(i) {
+                unsafe { self.items[i].assume_init_drop() }
+            }
+        }
+        self.bits.clear();
     }
 
-    /// This function checks if the SparseVector is empty, returning `true` if it is and `false` otherwise.
     pub fn is_empty(&self) -> bool {
-        self.storage.is_empty()
+        self.bits.is_empty()
     }
 
-    /// This function returns an iterator over the positions of all the used (non-None) elements in the SparseVector.
     pub fn iter_keys(&self) -> impl DoubleEndedIterator<Item = usize> + '_ {
-        self.storage.iter().enumerate().filter_map(
-            |(i, x)| {
-                if x.is_some() {
-                    Some(i)
-                } else {
-                    None
-                }
-            },
-        )
+        self.items.iter().enumerate().filter_map(|x| {
+            if self.bits.check(x.0) {
+                Some(x.0)
+            } else {
+                None
+            }
+        })
     }
 
-    /// This function returns an iterator over pairs of positions and references to all the used (non-None) elements in the SparseVector.
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = (usize, &X)> {
-        self.storage
-            .iter()
-            .enumerate()
-            .filter_map(|(i, x)| x.as_ref().map(|v| (i, v)))
+        self.items.iter().enumerate().filter_map(move |x| {
+            if self.bits.check(x.0) {
+                unsafe { Some((x.0, x.1.assume_init_ref())) }
+            } else {
+                None
+            }
+        })
+    }
+
+    #[inline]
+    pub fn first_free_pos(&self) -> Option<usize> {
+        self.bits.first_empty()
+    }
+
+    #[inline]
+    pub fn last_used_pos(&self) -> Option<usize> {
+        self.bits.last()
+    }
+}
+
+impl<X: Clone, const WIDTH: usize> Clone for BitArray<X, WIDTH> {
+    fn clone(&self) -> Self {
+        let mut new_items: Box<[MaybeUninit<X>; WIDTH]> =
+            Box::new(unsafe { MaybeUninit::uninit().assume_init() });
+
+        for i in 0..WIDTH {
+            if self.bits.check(i) {
+                new_items[i] = MaybeUninit::new(unsafe { self.items[i].assume_init_ref() }.clone());
+            }
+        }
+        Self {
+            items: new_items,
+            bits: self.bits.clone(),
+        }
+    }
+}
+
+impl<X, const WIDTH: usize> Drop for BitArray<X, WIDTH> {
+    fn drop(&mut self) {
+        for i in 0..WIDTH {
+            if self.bits.check(i) {
+                unsafe { self.items[i].assume_init_drop() }
+            }
+        }
+        self.bits.clear();
+    }
+}
+
+// Define a custom error enum representing different error cases for the Trie
+#[derive(Clone, Debug)]
+pub enum TrieError {
+    IllegalArguments,
+    NotFound,
+    KeyNotFound,
+    SnapshotNotFound,
+    SnapshotEmpty,
+    SnapshotNotClosed,
+    SnapshotAlreadyClosed,
+    SnapshotReadersNotClosed,
+    TreeAlreadyClosed,
+    FixedKeyLengthExceeded,
+    Other(String),
+}
+
+impl Error for TrieError {}
+
+// Implement the Display trait to define how the error should be formatted as a string
+impl fmt::Display for TrieError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TrieError::IllegalArguments => write!(f, "Illegal arguments"),
+            TrieError::NotFound => write!(f, "Not found"),
+            TrieError::KeyNotFound => write!(f, "Key not found"),
+            TrieError::SnapshotNotFound => write!(f, "Snapshot not found"),
+            TrieError::SnapshotNotClosed => write!(f, "Snapshot not closed"),
+            TrieError::SnapshotAlreadyClosed => write!(f, "Snapshot already closed"),
+            TrieError::SnapshotReadersNotClosed => {
+                write!(f, "Readers in the snapshot are not closed")
+            }
+            TrieError::TreeAlreadyClosed => write!(f, "Tree already closed"),
+            TrieError::Other(ref message) => write!(f, "Other error: {}", message),
+            TrieError::SnapshotEmpty => write!(f, "Snapshot is empty"),
+            TrieError::FixedKeyLengthExceeded => write!(f, "Fixed key length exceeded"),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SparseVector;
-
-    #[test]
-    fn new() {
-        let v: SparseVector<i32, 10> = SparseVector::new();
-        assert_eq!(v.storage.capacity(), 10);
-    }
+    use super::BitArray;
 
     #[test]
     fn push_and_pop() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
-        let index = v.push(5);
+        let mut v: BitArray<i32, 10> = BitArray::new();
+        let index = v.push(5).unwrap();
         assert_eq!(v.get(index), Some(&5));
         assert_eq!(v.pop(), Some(5));
     }
 
     #[test]
     fn last() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
         v.push(6);
         assert_eq!(v.last(), Some(&6));
@@ -455,7 +594,7 @@ mod tests {
 
     #[test]
     fn last_used_pos() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
         v.push(6);
         assert_eq!(v.last_used_pos(), Some(1));
@@ -463,21 +602,21 @@ mod tests {
 
     #[test]
     fn first_free_pos() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
-        assert_eq!(v.first_free_pos(), 1);
+        assert_eq!(v.first_free_pos().unwrap(), 1);
     }
 
     #[test]
     fn get_and_set() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.set(5, 6);
         assert_eq!(v.get(5), Some(&6));
     }
 
     #[test]
     fn get_mut() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.set(5, 6);
         if let Some(value) = v.get_mut(5) {
             *value = 7;
@@ -487,15 +626,17 @@ mod tests {
 
     #[test]
     fn erase() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
+
+        assert_eq!(*v.get(0).unwrap(), 5);
         assert_eq!(v.erase(0), Some(5));
         assert_eq!(v.get(0), None);
     }
 
     #[test]
     fn clear() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
         v.clear();
         assert!(v.is_empty());
@@ -503,7 +644,7 @@ mod tests {
 
     #[test]
     fn is_empty() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         assert!(v.is_empty());
         v.push(5);
         assert!(!v.is_empty());
@@ -511,7 +652,7 @@ mod tests {
 
     #[test]
     fn iter_keys() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
         v.push(6);
         let keys: Vec<usize> = v.iter_keys().collect();
@@ -520,7 +661,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        let mut v: SparseVector<i32, 10> = SparseVector::new();
+        let mut v: BitArray<i32, 10> = BitArray::new();
         v.push(5);
         v.push(6);
         let values: Vec<(usize, &i32)> = v.iter().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,29 +52,29 @@ impl<T: Key + Clone + PartialOrd + PartialEq + Ord + Debug + for<'a> From<&'a [u
 // because no string can have any characters after the NULL byte!
 //
 #[derive(Clone, Debug, Eq)]
-pub struct FixedKey<const SIZE: usize> {
+pub struct FixedSizeKey<const SIZE: usize> {
     content: [u8; SIZE],
     len: usize,
 }
 
-impl<const SIZE: usize> PartialEq for FixedKey<SIZE> {
+impl<const SIZE: usize> PartialEq for FixedSizeKey<SIZE> {
     fn eq(&self, other: &Self) -> bool {
         self.content[..self.len] == other.content[..other.len]
     }
 }
 
-impl<const SIZE: usize> PartialOrd for FixedKey<SIZE> {
+impl<const SIZE: usize> PartialOrd for FixedSizeKey<SIZE> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-impl<const SIZE: usize> Ord for FixedKey<SIZE> {
+impl<const SIZE: usize> Ord for FixedSizeKey<SIZE> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.content[..self.len].cmp(&other.content[..other.len])
     }
 }
 
-impl<const SIZE: usize> FixedKey<SIZE> {
+impl<const SIZE: usize> FixedSizeKey<SIZE> {
     // Create new instance with data ending in zero byte
     pub fn create_key(src: &[u8]) -> Self {
         debug_assert!(src.len() < SIZE);
@@ -109,19 +109,19 @@ impl<const SIZE: usize> FixedKey<SIZE> {
     }
 }
 
-impl<const SIZE: usize> Key for FixedKey<SIZE> {
+impl<const SIZE: usize> Key for FixedSizeKey<SIZE> {
     // Returns slice of the internal data up to the actual length
     fn as_slice(&self) -> &[u8] {
         &self.content[..self.len]
     }
 
-    // Creates a new instance of FixedKey consisting only of the initial part of the content
+    // Creates a new instance of FixedSizeKey consisting only of the initial part of the content
     fn prefix_before(&self, length: usize) -> Self {
         assert!(length <= self.len);
         Self::from_slice(&self.content[..length])
     }
 
-    // Creates a new instance of FixedKey excluding the initial part of the content
+    // Creates a new instance of FixedSizeKey excluding the initial part of the content
     fn prefix_after(&self, start: usize) -> Self {
         assert!(start <= self.len);
         Self::from_slice(&self.content[start..self.len])
@@ -149,12 +149,12 @@ impl<const SIZE: usize> Key for FixedKey<SIZE> {
     }
 }
 
-impl<const SIZE: usize> FromStr for FixedKey<SIZE> {
+impl<const SIZE: usize> FromStr for FixedSizeKey<SIZE> {
     type Err = TrieError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() >= SIZE {
-            return Err(TrieError::FixedKeyLengthExceeded);
+            return Err(TrieError::FixedSizeKeyLengthExceeded);
         }
         let mut arr = [0; SIZE];
         arr[..s.len()].copy_from_slice(s.as_bytes());
@@ -165,54 +165,54 @@ impl<const SIZE: usize> FromStr for FixedKey<SIZE> {
     }
 }
 
-impl<const SIZE: usize> From<&[u8]> for FixedKey<SIZE> {
+impl<const SIZE: usize> From<&[u8]> for FixedSizeKey<SIZE> {
     fn from(src: &[u8]) -> Self {
         Self::from_slice(src)
     }
 }
 
-impl<const N: usize> From<u8> for FixedKey<N> {
+impl<const N: usize> From<u8> for FixedSizeKey<N> {
     fn from(data: u8) -> Self {
         Self::from_slice(data.to_be_bytes().as_ref())
     }
 }
 
-impl<const N: usize> From<u16> for FixedKey<N> {
+impl<const N: usize> From<u16> for FixedSizeKey<N> {
     fn from(data: u16) -> Self {
         Self::from_slice(data.to_be_bytes().as_ref())
     }
 }
 
-impl<const N: usize> From<u64> for FixedKey<N> {
+impl<const N: usize> From<u64> for FixedSizeKey<N> {
     fn from(data: u64) -> Self {
         Self::from_slice(data.to_be_bytes().as_ref())
     }
 }
 
-impl<const N: usize> From<&str> for FixedKey<N> {
+impl<const N: usize> From<&str> for FixedSizeKey<N> {
     fn from(data: &str) -> Self {
         Self::from_str(data).unwrap()
     }
 }
 
-impl<const N: usize> From<String> for FixedKey<N> {
+impl<const N: usize> From<String> for FixedSizeKey<N> {
     fn from(data: String) -> Self {
         Self::from_string(&data)
     }
 }
-impl<const N: usize> From<&String> for FixedKey<N> {
+impl<const N: usize> From<&String> for FixedSizeKey<N> {
     fn from(data: &String) -> Self {
         Self::from_string(data)
     }
 }
 
-// A VariableKey is a variable-length datatype with NULL byte appended to it.
+// A VariableSizeKey is a variable-length datatype with NULL byte appended to it.
 #[derive(Clone, PartialEq, PartialOrd, Ord, Eq, Debug)]
-pub struct VariableKey {
+pub struct VariableSizeKey {
     data: Vec<u8>,
 }
 
-impl VariableKey {
+impl VariableSizeKey {
     pub fn key(src: &[u8]) -> Self {
         let mut data = Vec::with_capacity(src.len() + 1);
         data.extend_from_slice(src);
@@ -256,7 +256,7 @@ impl VariableKey {
     }
 }
 
-impl FromStr for VariableKey {
+impl FromStr for VariableSizeKey {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -267,21 +267,21 @@ impl FromStr for VariableKey {
     }
 }
 
-impl From<&[u8]> for VariableKey {
+impl From<&[u8]> for VariableSizeKey {
     fn from(src: &[u8]) -> Self {
         Self::from_slice(src)
     }
 }
 
-impl Key for VariableKey {
+impl Key for VariableSizeKey {
     fn prefix_before(&self, length: usize) -> Self {
         assert!(length <= self.data.len());
-        VariableKey::from_slice(&self.data[..length])
+        VariableSizeKey::from_slice(&self.data[..length])
     }
 
     fn prefix_after(&self, start: usize) -> Self {
         assert!(start <= self.data.len());
-        VariableKey::from_slice(&self.data[start..self.data.len()])
+        VariableSizeKey::from_slice(&self.data[start..self.data.len()])
     }
 
     #[inline(always)]
@@ -545,7 +545,7 @@ pub enum TrieError {
     SnapshotAlreadyClosed,
     SnapshotReadersNotClosed,
     TreeAlreadyClosed,
-    FixedKeyLengthExceeded,
+    FixedSizeKeyLengthExceeded,
     Other(String),
 }
 
@@ -567,7 +567,7 @@ impl fmt::Display for TrieError {
             TrieError::TreeAlreadyClosed => write!(f, "Tree already closed"),
             TrieError::Other(ref message) => write!(f, "Other error: {}", message),
             TrieError::SnapshotEmpty => write!(f, "Snapshot is empty"),
-            TrieError::FixedKeyLengthExceeded => write!(f, "Fixed key length exceeded"),
+            TrieError::FixedSizeKeyLengthExceeded => write!(f, "Fixed key length exceeded"),
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
-use crate::{KeyTrait, SparseVector};
+use crate::{BitArray, KeyTrait};
 
 /*
     Immutable nodes
@@ -379,8 +379,8 @@ impl<P: KeyTrait + Clone, N: Version, const WIDTH: usize> Drop for FlatNode<P, N
 pub struct Node48<P: KeyTrait + Clone, N: Version> {
     pub(crate) prefix: P,
     pub(crate) version: u64,
-    keys: SparseVector<u8, 256>,
-    children: SparseVector<Arc<N>, 48>,
+    keys: BitArray<u8, 256>,
+    children: BitArray<Arc<N>, 48>,
     num_children: u8,
 }
 
@@ -389,14 +389,14 @@ impl<P: KeyTrait + Clone, N: Version> Node48<P, N> {
         Self {
             prefix,
             version: 0,
-            keys: SparseVector::new(),
-            children: SparseVector::new(),
+            keys: BitArray::new(),
+            children: BitArray::new(),
             num_children: 0,
         }
     }
 
     pub fn insert_child(&mut self, key: u8, node: Arc<N>) {
-        let pos = self.children.first_free_pos();
+        let pos = self.children.first_free_pos().unwrap();
         assert!(pos < 48);
 
         self.keys.set(key as usize, pos as u8);
@@ -546,7 +546,7 @@ pub struct Node256<P: KeyTrait + Clone, N: Version> {
     pub(crate) prefix: P,    // Prefix associated with the node
     pub(crate) version: u64, // Version for node256
 
-    children: SparseVector<Arc<N>, 256>,
+    children: BitArray<Arc<N>, 256>,
     num_children: usize,
 }
 
@@ -555,7 +555,7 @@ impl<P: KeyTrait + Clone, N: Version> Node256<P, N> {
         Self {
             prefix,
             version: 0,
-            children: SparseVector::new(),
+            children: BitArray::new(),
             num_children: 0,
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -684,7 +684,7 @@ impl<P: KeyTrait + Clone, N: Version> Drop for Node256<P, N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::FixedKey;
+    use crate::FixedSizeKey;
 
     use super::{FlatNode, Node256, Node48, NodeTrait, TwigNode, Version};
     use std::mem::MaybeUninit;
@@ -722,47 +722,47 @@ mod tests {
 
     #[test]
     fn flatnode() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         node_test(
-            FlatNode::<FixedKey<8>, usize, 4>::new(dummy_prefix.clone()),
+            FlatNode::<FixedSizeKey<8>, usize, 4>::new(dummy_prefix.clone()),
             4,
         );
         node_test(
-            FlatNode::<FixedKey<8>, usize, 16>::new(dummy_prefix.clone()),
+            FlatNode::<FixedSizeKey<8>, usize, 16>::new(dummy_prefix.clone()),
             16,
         );
         node_test(
-            FlatNode::<FixedKey<8>, usize, 32>::new(dummy_prefix.clone()),
+            FlatNode::<FixedSizeKey<8>, usize, 32>::new(dummy_prefix.clone()),
             32,
         );
         node_test(
-            FlatNode::<FixedKey<8>, usize, 48>::new(dummy_prefix.clone()),
+            FlatNode::<FixedSizeKey<8>, usize, 48>::new(dummy_prefix.clone()),
             48,
         );
         node_test(
-            FlatNode::<FixedKey<8>, usize, 64>::new(dummy_prefix.clone()),
+            FlatNode::<FixedSizeKey<8>, usize, 64>::new(dummy_prefix.clone()),
             64,
         );
 
         // Resize from 16 to 4
-        let mut node = FlatNode::<FixedKey<8>, usize, 16>::new(dummy_prefix.clone());
+        let mut node = FlatNode::<FixedSizeKey<8>, usize, 16>::new(dummy_prefix.clone());
         for i in 0..4 {
             node = node.add_child(i as u8, i);
         }
 
-        let resized: FlatNode<FixedKey<8>, usize, 4> = node.resize();
+        let resized: FlatNode<FixedSizeKey<8>, usize, 4> = node.resize();
         assert_eq!(resized.num_children, 4);
         for i in 0..4 {
             assert!(matches!(resized.find_child(i as u8), Some(v) if *v == i.into()));
         }
 
         // Resize from 4 to 16
-        let mut node = FlatNode::<FixedKey<8>, usize, 4>::new(dummy_prefix.clone());
+        let mut node = FlatNode::<FixedSizeKey<8>, usize, 4>::new(dummy_prefix.clone());
         for i in 0..4 {
             node = node.add_child(i as u8, i);
         }
-        let mut resized: FlatNode<FixedKey<8>, usize, 16> = node.resize();
+        let mut resized: FlatNode<FixedSizeKey<8>, usize, 16> = node.resize();
         assert_eq!(resized.num_children, 4);
         for i in 4..16 {
             resized = resized.add_child(i as u8, i);
@@ -773,7 +773,7 @@ mod tests {
         }
 
         // Resize from 16 to 48
-        let mut node = FlatNode::<FixedKey<8>, usize, 16>::new(dummy_prefix.clone());
+        let mut node = FlatNode::<FixedSizeKey<8>, usize, 16>::new(dummy_prefix.clone());
         for i in 0..16 {
             node = node.add_child(i as u8, i);
         }
@@ -785,7 +785,7 @@ mod tests {
         }
 
         // Additional test for adding and deleting children
-        let mut node = FlatNode::<FixedKey<8>, usize, 4>::new(dummy_prefix);
+        let mut node = FlatNode::<FixedSizeKey<8>, usize, 4>::new(dummy_prefix);
         node = node.add_child(1, 1);
         node = node.add_child(2, 2);
         node = node.add_child(3, 3);
@@ -806,10 +806,10 @@ mod tests {
 
     #[test]
     fn node48() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Create and test Node48
-        let mut n48 = Node48::<FixedKey<8>, u8>::new(dummy_prefix.clone());
+        let mut n48 = Node48::<FixedSizeKey<8>, u8>::new(dummy_prefix.clone());
         for i in 0..48 {
             n48 = n48.add_child(i, i);
         }
@@ -824,7 +824,7 @@ mod tests {
         }
 
         // Resize from 48 to 16
-        let mut node = Node48::<FixedKey<8>, u8>::new(dummy_prefix.clone());
+        let mut node = Node48::<FixedSizeKey<8>, u8>::new(dummy_prefix.clone());
         for i in 0..18 {
             node = node.add_child(i, i);
         }
@@ -840,7 +840,7 @@ mod tests {
         }
 
         // Resize from 48 to 4
-        let mut node = Node48::<FixedKey<8>, u8>::new(dummy_prefix.clone());
+        let mut node = Node48::<FixedSizeKey<8>, u8>::new(dummy_prefix.clone());
         for i in 0..4 {
             node = node.add_child(i, i);
         }
@@ -851,7 +851,7 @@ mod tests {
         }
 
         // Resize from 48 to 256
-        let mut node = Node48::<FixedKey<8>, u8>::new(dummy_prefix);
+        let mut node = Node48::<FixedSizeKey<8>, u8>::new(dummy_prefix);
         for i in 0..48 {
             node = node.add_child(i, i);
         }
@@ -865,10 +865,10 @@ mod tests {
 
     #[test]
     fn node256() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         node_test(
-            Node256::<FixedKey<8>, usize>::new(dummy_prefix.clone()),
+            Node256::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone()),
             255,
         );
 
@@ -896,16 +896,16 @@ mod tests {
     #[test]
     fn flatnode_update_version() {
         const WIDTH: usize = 4;
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Prepare some child nodes
-        let mut child1 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut child1 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
         child1.version = 5;
-        let mut child2 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut child2 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
         child2.version = 10;
-        let mut child3 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut child3 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
         child3.version = 3;
-        let mut child4 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut child4 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
         child4.version = 7;
 
         let mut parent = FlatNode {
@@ -926,7 +926,7 @@ mod tests {
         assert_eq!(parent.version(), 10);
 
         // Add a new child with a larger version (15), parent's version should update to 15
-        let mut child5 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut child5 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
         child5.version = 15;
         parent = parent.add_child(3, child5);
         assert_eq!(parent.version(), 15);
@@ -936,7 +936,7 @@ mod tests {
         assert_eq!(parent.version(), 10);
 
         // Update a child's version to be the largest (20), parent's version should update to 20
-        let mut child6 = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix);
+        let mut child6 = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix);
         child6.version = 20;
         parent.children[2] = MaybeUninit::new(Some(Arc::new(child6)));
         parent.update_version();
@@ -946,16 +946,17 @@ mod tests {
     #[test]
     fn flatnode_repeated_update_version() {
         const WIDTH: usize = 1;
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
-        let child = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
-        let mut parent: FlatNode<FixedKey<8>, FlatNode<FixedKey<8>, usize, 1>, 1> = FlatNode {
-            prefix: dummy_prefix,
-            version: 6,
-            keys: [0; WIDTH],
-            children: Box::new([MaybeUninit::new(Some(Arc::new(child)))]),
-            num_children: 1,
-        };
+        let child = FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+        let mut parent: FlatNode<FixedSizeKey<8>, FlatNode<FixedSizeKey<8>, usize, 1>, 1> =
+            FlatNode {
+                prefix: dummy_prefix,
+                version: 6,
+                keys: [0; WIDTH],
+                children: Box::new([MaybeUninit::new(Some(Arc::new(child)))]),
+                num_children: 1,
+            };
 
         // Calling update_version once should update the version.
         parent.update_version();
@@ -969,19 +970,20 @@ mod tests {
     #[test]
     fn node48_update_version() {
         const WIDTH: usize = 4;
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Prepare some child nodes with varying versions
         let children: Vec<_> = (0..WIDTH)
             .map(|i| {
-                let mut child = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+                let mut child =
+                    FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
                 child.version = i as u64;
                 child
             })
             .collect();
 
-        let mut parent: Node48<FixedKey<8>, FlatNode<FixedKey<8>, usize, WIDTH>> =
-            Node48::<FixedKey<8>, FlatNode<FixedKey<8>, usize, WIDTH>>::new(dummy_prefix);
+        let mut parent: Node48<FixedSizeKey<8>, FlatNode<FixedSizeKey<8>, usize, WIDTH>> =
+            Node48::<FixedSizeKey<8>, FlatNode<FixedSizeKey<8>, usize, WIDTH>>::new(dummy_prefix);
 
         // Add children to parent
         for (i, child) in children.iter().enumerate() {
@@ -996,19 +998,20 @@ mod tests {
     #[test]
     fn node256_update_version() {
         const WIDTH: usize = 256;
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Prepare some child nodes with varying versions
         let children: Vec<_> = (0..WIDTH)
             .map(|i| {
-                let mut child = FlatNode::<FixedKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
+                let mut child =
+                    FlatNode::<FixedSizeKey<8>, usize, WIDTH>::new(dummy_prefix.clone());
                 child.version = i as u64;
                 child
             })
             .collect();
 
-        let mut parent: Node256<FixedKey<8>, FlatNode<FixedKey<8>, usize, WIDTH>> =
-            Node256::<FixedKey<8>, FlatNode<FixedKey<8>, usize, WIDTH>>::new(dummy_prefix);
+        let mut parent: Node256<FixedSizeKey<8>, FlatNode<FixedSizeKey<8>, usize, WIDTH>> =
+            Node256::<FixedSizeKey<8>, FlatNode<FixedSizeKey<8>, usize, WIDTH>>::new(dummy_prefix);
 
         // Add children to parent
         for (i, child) in children.iter().enumerate() {
@@ -1025,20 +1028,20 @@ mod tests {
     #[test]
     fn twig_nodes() {
         const WIDTH: usize = 4;
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Prepare some child nodes
         let mut twig1 =
-            TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
         twig1.version = 5;
         let mut twig2 =
-            TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
         twig2.version = 10;
         let mut twig3 =
-            TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
         twig3.version = 3;
         let mut twig4 =
-            TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
         twig4.version = 7;
 
         let mut parent = FlatNode {
@@ -1061,9 +1064,9 @@ mod tests {
 
     #[test]
     fn twig_insert() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
-        let node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
 
         let new_node = node.insert(42, 123, 0);
         assert_eq!(node.values.len(), 0);
@@ -1074,9 +1077,9 @@ mod tests {
 
     #[test]
     fn twig_insert_mut() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
-        let mut node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
 
         node.insert_mut(42, 123, 0);
         assert_eq!(node.values.len(), 1);
@@ -1086,8 +1089,8 @@ mod tests {
 
     #[test]
     fn twig_get_latest_leaf() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let latest_leaf = node.get_latest_leaf();
@@ -1096,8 +1099,8 @@ mod tests {
 
     #[test]
     fn twig_get_latest_value() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let latest_value = node.get_latest_value();
@@ -1106,8 +1109,8 @@ mod tests {
 
     #[test]
     fn twig_get_leaf_by_version() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let leaf_by_ts = node.get_leaf_by_version(123);
@@ -1118,8 +1121,8 @@ mod tests {
 
     #[test]
     fn twig_iter() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let mut iter = node.iter();
@@ -1130,10 +1133,10 @@ mod tests {
 
     #[test]
     fn memory_leak() {
-        let dummy_prefix: FixedKey<8> = FixedKey::create_key("foo".as_bytes());
+        let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Create and test flatnode
-        let mut node = FlatNode::<FixedKey<8>, usize, 4>::new(dummy_prefix.clone());
+        let mut node = FlatNode::<FixedSizeKey<8>, usize, 4>::new(dummy_prefix.clone());
         for i in 0..4 {
             node = node.add_child(i as u8, i);
         }
@@ -1143,7 +1146,7 @@ mod tests {
         }
 
         // Create and test Node48
-        let mut n48 = Node48::<FixedKey<8>, u8>::new(dummy_prefix.clone());
+        let mut n48 = Node48::<FixedSizeKey<8>, u8>::new(dummy_prefix.clone());
         for i in 0..48 {
             n48 = n48.add_child(i, i);
         }
@@ -1165,7 +1168,7 @@ mod tests {
 
     #[test]
     fn cache_line_size() {
-        assert!(std::mem::size_of::<FlatNode::<FixedKey<8>, usize, 4>>() <= 64);
-        assert!(std::mem::size_of::<FlatNode::<FixedKey<8>, usize, 16>>() <= 64);
+        assert!(std::mem::size_of::<FlatNode::<FixedSizeKey<8>, usize, 4>>() <= 64);
+        assert!(std::mem::size_of::<FlatNode::<FixedSizeKey<8>, usize, 16>>() <= 64);
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -166,24 +166,24 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
 mod tests {
     use crate::art::Tree;
     use crate::iter::IterationPointer;
-    use crate::VariableKey;
+    use crate::VariableSizeKey;
     use std::str::FromStr;
 
     #[test]
     fn snapshot_creation() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
         let keys = ["key_1", "key_2", "key_3"];
 
         for key in keys.iter() {
             assert!(tree
-                .insert(&VariableKey::from_str(key).unwrap(), 1, 0, 0)
+                .insert(&VariableSizeKey::from_str(key).unwrap(), 1, 0, 0)
                 .is_ok());
         }
 
         let mut snap1 = tree.create_snapshot().unwrap();
         let key_to_insert = "key_1";
         assert!(snap1
-            .insert(&VariableKey::from_str(key_to_insert).unwrap(), 1, 0)
+            .insert(&VariableSizeKey::from_str(key_to_insert).unwrap(), 1, 0)
             .is_ok());
 
         let expected_snap_ts = keys.len() as u64 + 1;
@@ -196,11 +196,11 @@ mod tests {
 
     #[test]
     fn snapshot_isolation() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
-        let key_1 = VariableKey::from_str("key_1").unwrap();
-        let key_2 = VariableKey::from_str("key_2").unwrap();
-        let key_3_snap1 = VariableKey::from_str("key_3_snap1").unwrap();
-        let key_3_snap2 = VariableKey::from_str("key_3_snap2").unwrap();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
+        let key_1 = VariableSizeKey::from_str("key_1").unwrap();
+        let key_2 = VariableSizeKey::from_str("key_2").unwrap();
+        let key_3_snap1 = VariableSizeKey::from_str("key_3_snap1").unwrap();
+        let key_3_snap2 = VariableSizeKey::from_str("key_3_snap2").unwrap();
 
         assert!(tree.insert(&key_1, 1, 0, 0).is_ok());
 
@@ -242,11 +242,11 @@ mod tests {
 
     #[test]
     fn snapshot_readers() {
-        let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
-        let key_1 = VariableKey::from_str("key_1").unwrap();
-        let key_2 = VariableKey::from_str("key_2").unwrap();
-        let key_3 = VariableKey::from_str("key_3").unwrap();
-        let key_4 = VariableKey::from_str("key_4").unwrap();
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::<VariableSizeKey, i32>::new();
+        let key_1 = VariableSizeKey::from_str("key_1").unwrap();
+        let key_2 = VariableSizeKey::from_str("key_2").unwrap();
+        let key_3 = VariableSizeKey::from_str("key_3").unwrap();
+        let key_4 = VariableSizeKey::from_str("key_4").unwrap();
 
         assert!(tree.insert(&key_1, 1, 0, 0).is_ok());
         assert!(tree.insert(&key_2, 1, 0, 0).is_ok());
@@ -277,7 +277,7 @@ mod tests {
         assert!(snap.close().is_ok());
     }
 
-    fn count_items(reader: &IterationPointer<VariableKey, i32>) -> usize {
+    fn count_items(reader: &IterationPointer<VariableSizeKey, i32>) -> usize {
         let mut len = 0;
         for _ in reader.iter() {
             len += 1;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,13 +1,14 @@
 //! This module defines the Snapshot struct for managing snapshots within a Trie structure.
-use std::cell::Cell;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use hashbrown::HashSet;
 
-use crate::art::{Node, TrieError};
+use crate::art::Node;
 use crate::iter::IterationPointer;
 use crate::node::Version;
-use crate::KeyTrait;
+use crate::{KeyTrait, TrieError};
 
 /// Represents a snapshot of the data within the Trie.
 pub struct Snapshot<P: KeyTrait, V: Clone> {
@@ -15,7 +16,7 @@ pub struct Snapshot<P: KeyTrait, V: Clone> {
     pub(crate) ts: u64,
     pub(crate) root: Option<Arc<Node<P, V>>>,
     pub(crate) readers: HashSet<u64>,
-    pub(crate) max_active_readers: Cell<u64>,
+    pub(crate) max_active_readers: AtomicU64,
     pub(crate) closed: bool,
 }
 
@@ -27,7 +28,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
             ts,
             root,
             readers: HashSet::new(),
-            max_active_readers: Cell::new(0),
+            max_active_readers: AtomicU64::new(0),
             closed: false,
         }
     }
@@ -95,10 +96,9 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         self.is_closed()?;
 
         // Check if there are any active readers for the snapshot
-        if self.max_active_readers.get() > 0 {
+        if self.max_active_readers.load(Ordering::SeqCst) > 0 {
             return Err(TrieError::SnapshotReadersNotClosed);
         }
-
         // Mark the snapshot as closed
         self.closed = true;
 
@@ -113,8 +113,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
             return Err(TrieError::SnapshotEmpty);
         }
 
-        let reader_id = self.max_active_readers.get() + 1;
-        self.max_active_readers.set(reader_id);
+        let reader_id = self.max_active_readers.fetch_add(1, Ordering::SeqCst) + 1;
         self.readers.insert(reader_id);
         Ok(IterationPointer::new(
             self.root.as_ref().unwrap().clone(),
@@ -126,7 +125,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         // Check if the snapshot is already closed
         self.is_closed()?;
 
-        Ok(self.max_active_readers.get())
+        Ok(self.max_active_readers.load(Ordering::SeqCst))
     }
 
     pub fn close_reader(&mut self, reader_id: u64) -> Result<(), TrieError> {
@@ -134,8 +133,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         self.is_closed()?;
 
         self.readers.remove(&reader_id);
-        let readers = self.max_active_readers.get();
-        self.max_active_readers.set(readers - 1);
+        let _readers = self.max_active_readers.fetch_sub(1, Ordering::SeqCst);
         Ok(())
     }
 
@@ -169,6 +167,7 @@ mod tests {
     use crate::art::Tree;
     use crate::iter::IterationPointer;
     use crate::VariableKey;
+    use std::str::FromStr;
 
     #[test]
     fn snapshot_creation() {
@@ -176,13 +175,15 @@ mod tests {
         let keys = ["key_1", "key_2", "key_3"];
 
         for key in keys.iter() {
-            assert!(tree.insert(&VariableKey::from_str(key), 1, 0, 0).is_ok());
+            assert!(tree
+                .insert(&VariableKey::from_str(key).unwrap(), 1, 0, 0)
+                .is_ok());
         }
 
         let mut snap1 = tree.create_snapshot().unwrap();
         let key_to_insert = "key_1";
         assert!(snap1
-            .insert(&VariableKey::from_str(key_to_insert), 1, 0)
+            .insert(&VariableKey::from_str(key_to_insert).unwrap(), 1, 0)
             .is_ok());
 
         let expected_snap_ts = keys.len() as u64 + 1;
@@ -196,10 +197,10 @@ mod tests {
     #[test]
     fn snapshot_isolation() {
         let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
-        let key_1 = VariableKey::from_str("key_1");
-        let key_2 = VariableKey::from_str("key_2");
-        let key_3_snap1 = VariableKey::from_str("key_3_snap1");
-        let key_3_snap2 = VariableKey::from_str("key_3_snap2");
+        let key_1 = VariableKey::from_str("key_1").unwrap();
+        let key_2 = VariableKey::from_str("key_2").unwrap();
+        let key_3_snap1 = VariableKey::from_str("key_3_snap1").unwrap();
+        let key_3_snap2 = VariableKey::from_str("key_3_snap2").unwrap();
 
         assert!(tree.insert(&key_1, 1, 0, 0).is_ok());
 
@@ -242,10 +243,10 @@ mod tests {
     #[test]
     fn snapshot_readers() {
         let mut tree: Tree<VariableKey, i32> = Tree::<VariableKey, i32>::new();
-        let key_1 = VariableKey::from_str("key_1");
-        let key_2 = VariableKey::from_str("key_2");
-        let key_3 = VariableKey::from_str("key_3");
-        let key_4 = VariableKey::from_str("key_4");
+        let key_1 = VariableKey::from_str("key_1").unwrap();
+        let key_2 = VariableKey::from_str("key_2").unwrap();
+        let key_3 = VariableKey::from_str("key_3").unwrap();
+        let key_4 = VariableKey::from_str("key_4").unwrap();
 
         assert!(tree.insert(&key_1, 1, 0, 0).is_ok());
         assert!(tree.insert(&key_2, 1, 0, 0).is_ok());


### PR DESCRIPTION
This PR ports changes from surrealkv index into vart. It makes the following changes

- Remove usage of assert during key creation
- Change VariableKey to VariableSizeKey
- Change FixedKey to FixedSizeKey
