### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vart"
 publish = true
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
v0.1.2 introduced [breaking changes](https://github.com/surrealdb/surrealdb/actions/runs/8551058675/job/23429259913?pr=3805#step:6:351). That version should have been released as 0.2 instead. To fix that, we need to release the correct version and yank 0.1.2.