### PR TITLE
chore: add versioned apis

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -2553,11 +2553,12 @@ mod tests {
         tree.bulk_insert(&entries, false).unwrap();
 
         // Define a range that encompasses all keys
-        let range = VariableSizeKey::from("test1".as_bytes().to_vec())
-            ..=VariableSizeKey::from("test5".as_bytes().to_vec());
+        let range = VariableSizeKey::from_slice_with_termination("test1".as_bytes())
+            ..=VariableSizeKey::from_slice_with_termination("test5".as_bytes());
 
         // Collect results of the range scan
         let results: Vec<_> = tree.range(range).collect();
+        assert_eq!(results.len(), insert_words.len());
 
         // Expected order
         let expected_order = ["test1", "test2", "test3", "test4", "test5"];

--- a/src/art.rs
+++ b/src/art.rs
@@ -1065,7 +1065,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
         self.insert_common(key, value, version, ts, true)
     }
 
-    pub fn insert_without_version_increment_check(
+    pub fn insert_unchecked(
         &mut self,
         key: &P,
         value: V,
@@ -2470,7 +2470,7 @@ mod tests {
             let id = format!("key{}", i + 1);
             let key = VariableSizeKey::from_str(&id).unwrap();
             if tree
-                .insert_without_version_increment_check(&key, rng.gen::<i32>(), version as u64, 0)
+                .insert_unchecked(&key, rng.gen::<i32>(), version as u64, 0)
                 .is_ok()
             {
                 expected_entries += 1;
@@ -2509,7 +2509,7 @@ mod tests {
 
         for i in (0..num_keys).rev() {
             let key = VariableSizeKey::from_str(&format!("key{}", i)).unwrap();
-            tree.insert_without_version_increment_check(&key, i as i32, i, 0)
+            tree.insert_unchecked(&key, i as i32, i, 0)
                 .unwrap();
         }
 
@@ -2527,9 +2527,9 @@ mod tests {
         let key = VariableSizeKey::from_str("key1").unwrap();
 
         // Insert the same key with two different versions
-        tree.insert_without_version_increment_check(&key, 2, 2, 0)
+        tree.insert_unchecked(&key, 2, 2, 0)
             .unwrap(); // Second version
-        tree.insert_without_version_increment_check(&key, 1, 1, 0)
+        tree.insert_unchecked(&key, 1, 1, 0)
             .unwrap(); // First version
 
         // Verify the order during iteration
@@ -2552,9 +2552,9 @@ mod tests {
         // Insert two versions for each key
         for i in 0..num_keys {
             let key = VariableSizeKey::from_str(&format!("key{}", i)).unwrap();
-            tree.insert_without_version_increment_check(&key, i as u64 + 1000, 2, 0)
+            tree.insert_unchecked(&key, i as u64 + 1000, 2, 0)
                 .unwrap(); // Second version
-            tree.insert_without_version_increment_check(&key, i as u64, 1, 0)
+            tree.insert_unchecked(&key, i as u64, 1, 0)
                 .unwrap(); // First version
         }
 

--- a/src/art.rs
+++ b/src/art.rs
@@ -2775,6 +2775,4 @@ mod tests {
         assert_eq!(version, 1);
         assert_eq!(t, ts);
     }
-
-
 }

--- a/src/art.rs
+++ b/src/art.rs
@@ -824,8 +824,6 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
     }
 
     /// Recursively searches for a key in the node and its children.
-    ///
-    /// Recursively searches for a key in the current node and its child nodes, considering versions.
     pub(crate) fn get_recurse(
         cur_node: &Node<P, V>,
         key: &P,

--- a/src/art.rs
+++ b/src/art.rs
@@ -2509,8 +2509,7 @@ mod tests {
 
         for i in (0..num_keys).rev() {
             let key = VariableSizeKey::from_str(&format!("key{}", i)).unwrap();
-            tree.insert_unchecked(&key, i as i32, i, 0)
-                .unwrap();
+            tree.insert_unchecked(&key, i as i32, i, 0).unwrap();
         }
 
         // Verify total entries
@@ -2527,10 +2526,8 @@ mod tests {
         let key = VariableSizeKey::from_str("key1").unwrap();
 
         // Insert the same key with two different versions
-        tree.insert_unchecked(&key, 2, 2, 0)
-            .unwrap(); // Second version
-        tree.insert_unchecked(&key, 1, 1, 0)
-            .unwrap(); // First version
+        tree.insert_unchecked(&key, 2, 2, 0).unwrap(); // Second version
+        tree.insert_unchecked(&key, 1, 1, 0).unwrap(); // First version
 
         // Verify the order during iteration
         let mut iter = tree.iter();
@@ -2552,10 +2549,8 @@ mod tests {
         // Insert two versions for each key
         for i in 0..num_keys {
             let key = VariableSizeKey::from_str(&format!("key{}", i)).unwrap();
-            tree.insert_unchecked(&key, i as u64 + 1000, 2, 0)
-                .unwrap(); // Second version
-            tree.insert_unchecked(&key, i as u64, 1, 0)
-                .unwrap(); // First version
+            tree.insert_unchecked(&key, i as u64 + 1000, 2, 0).unwrap(); // Second version
+            tree.insert_unchecked(&key, i as u64, 1, 0).unwrap(); // First version
         }
 
         // Verify get at version 0 gives the latest version for each key
@@ -2715,8 +2710,8 @@ mod tests {
         let value1_2 = 20;
         let ts1_1 = 100;
         let ts1_2 = 200;
-        tree.insert(&key1,  value1_1, 0, ts1_1).unwrap();
-        tree.insert(&key1, value1_2,0, ts1_2).unwrap();
+        tree.insert(&key1, value1_1, 0, ts1_1).unwrap();
+        tree.insert(&key1, value1_2, 0, ts1_2).unwrap();
 
         let history1 = tree.get_version_history(&key1).unwrap();
         assert_eq!(history1.len(), 2);
@@ -2748,6 +2743,37 @@ mod tests {
         // Scenario 3: Ensure no history for a non-existent key
         let key3 = VariableSizeKey::from_str("non_existent_key").unwrap();
         assert!(tree.get_version_history(&key3).is_err());
+    }
+
+    #[test]
+    fn test_retrieving_value_at_future_timestamp() {
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        let value = 10;
+        let ts_insert = 100;
+        let ts_future = 200;
+        tree.insert(&key, value, 0, ts_insert).unwrap();
+
+        let (retrieved_value, version, ts) = tree.get_at_ts(&key, ts_future).unwrap();
+        assert_eq!(retrieved_value, value);
+        assert_eq!(version, 1);
+        assert_eq!(ts, ts_insert);
+    }
+
+    #[test]
+    fn test_inserting_and_retrieving_with_same_timestamp() {
+        let mut tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        let value1 = 10;
+        let value2 = 20;
+        let ts = 100;
+        tree.insert_unchecked(&key, value1, 1, ts).unwrap();
+        tree.insert_unchecked(&key, value2, 1, ts).unwrap();
+
+        let (retrieved_value, version, t) = tree.get_at_ts(&key, ts).unwrap();
+        assert_eq!(retrieved_value, value2);
+        assert_eq!(version, 1);
+        assert_eq!(t, ts);
     }
 
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -405,8 +405,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in 1..versions_per_key + 1 {
-                tree.insert_unchecked(&key, i, version, 0_u64)
-                    .unwrap();
+                tree.insert_unchecked(&key, i, version, 0_u64).unwrap();
             }
         }
 
@@ -461,8 +460,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in (1..=versions_per_key).rev() {
-                tree.insert_unchecked(&key, i, version, 0_u64)
-                    .unwrap();
+                tree.insert_unchecked(&key, i, version, 0_u64).unwrap();
             }
         }
 
@@ -525,8 +523,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in 1..=versions_per_key {
-                tree.insert_unchecked(&key, i, version, 0_u64)
-                    .unwrap();
+                tree.insert_unchecked(&key, i, version, 0_u64).unwrap();
             }
         }
 
@@ -610,8 +607,7 @@ mod tests {
         let key: FixedSizeKey<16> = 1u16.into();
         let versions = [1, 2];
         for &version in &versions {
-            tree.insert_unchecked(&key, 1, version, 0_u64)
-                .unwrap();
+            tree.insert_unchecked(&key, 1, version, 0_u64).unwrap();
         }
 
         // Use iterator to iterate through the tree
@@ -654,8 +650,7 @@ mod tests {
         let key: FixedSizeKey<16> = 1u16.into();
         let versions = [1, 2];
         for &version in &versions {
-            tree.insert_unchecked(&key, 1, version, 0_u64)
-                .unwrap();
+            tree.insert_unchecked(&key, 1, version, 0_u64).unwrap();
         }
 
         // Define start and end keys for the range query

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -396,16 +396,30 @@ where
                 } else {
                     // stop iteration if the range end is exceeded
                     match range.end_bound() {
-                        Bound::Included(k) if &twig.key > k => break,
-                        Bound::Excluded(k) if &twig.key >= k => break,
+                        Bound::Included(k) if &twig.key > k => forward.iters.clear(),
+                        Bound::Excluded(k) if &twig.key >= k => forward.iters.clear(),
                         _ => {}
                     }
                 }
+            } else {
+                // Push the iterator if it is not a leaf node
+                forward.iters.push(NodeIter::new(res.iter()));
             }
         } else {
             // Pop the iterator if no more elements
             forward.iters.pop();
         }
+    }
+
+    // Iterate over all leafs in forward.leafs and append them to results
+    for leaf in forward.leafs {
+        let key = leaf.0.as_slice().to_vec();
+        let value = if include_values {
+            Some(leaf.1.clone())
+        } else {
+            None
+        };
+        results.push((key, value));
     }
 
     results

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,62 +5,6 @@ use std::sync::Arc;
 use crate::art::{Node, NodeType};
 use crate::KeyTrait;
 
-// TODO: need to add more tests for snapshot readers
-/// A structure representing a pointer for iterating over the Trie's key-value pairs.
-/// The purpose of this structure is to keep track of the total number of readers in a snapshot.
-pub struct IterationPointer<P: KeyTrait, V: Clone> {
-    root: Arc<Node<P, V>>,
-}
-
-impl<P: KeyTrait, V: Clone> IterationPointer<P, V> {
-    /// Creates a new IterationPointer instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `root` - The root node of the Trie.
-    ///
-    pub fn new(root: Arc<Node<P, V>>) -> IterationPointer<P, V> {
-        IterationPointer { root }
-    }
-
-    /// Returns an iterator over the key-value pairs within the Trie.
-    ///
-    /// # Returns
-    ///
-    /// Returns an Iter iterator instance.
-    ///
-    pub fn iter(&self) -> Iter<P, V> {
-        Iter::new(Some(&self.root))
-    }
-
-    /// Returns an iterator over all versions of the key-value pairs within the Trie.
-    pub fn iter_with_versions(&self) -> VersionedIter<P, V> {
-        VersionedIter::new(Some(&self.root))
-    }
-
-    /// Returns a range query iterator over the Trie.
-    pub fn range<'a, R>(
-        &'a self,
-        range: R,
-    ) -> impl Iterator<Item = (Vec<u8>, &'a V, &'a u64, &'a u64)>
-    where
-        R: RangeBounds<P> + 'a,
-    {
-        Range::new(Some(&self.root), range)
-    }
-
-    /// Returns a versioned range query iterator over the Trie.
-    pub fn range_with_versions<'a, R>(
-        &'a self,
-        range: R,
-    ) -> impl Iterator<Item = (Vec<u8>, &'a V, &'a u64, &'a u64)>
-    where
-        R: RangeBounds<P> + 'a,
-    {
-        Range::new_versioned(Some(&self.root), range)
-    }
-}
-
 type NodeIterator<'a, P, V> = Box<dyn Iterator<Item = (u8, &'a Arc<Node<P, V>>)> + 'a>;
 
 /// An iterator over the nodes in the Trie.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -252,6 +252,8 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
                 Some(other) => {
                     if let NodeType::Twig(twig) = &other.1.node_type {
                         if self.range.contains(&twig.key) {
+                            // If the query is versioned, iterate over all versions of the key
+                            // and add them to the leafs queue. Otherwise, add the latest version.
                             if self.is_versioned {
                                 for leaf in twig.iter() {
                                     self.forward.leafs.push_back((

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -7,6 +7,7 @@ use crate::KeyTrait;
 
 // TODO: need to add more tests for snapshot readers
 /// A structure representing a pointer for iterating over the Trie's key-value pairs.
+/// The purpose of this structure is to keep track of the total number of readers in a snapshot.
 pub struct IterationPointer<P: KeyTrait, V: Clone> {
     root: Arc<Node<P, V>>,
 }
@@ -32,7 +33,7 @@ impl<P: KeyTrait, V: Clone> IterationPointer<P, V> {
         Iter::new(Some(&self.root))
     }
 
-    /// Returns an iterator over all
+    /// Returns an iterator over all versions of the key-value pairs within the Trie.
     pub fn iter_with_versions(&self) -> VersionedIter<P, V> {
         VersionedIter::new(Some(&self.root))
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -405,7 +405,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in 1..versions_per_key + 1 {
-                tree.insert_without_version_increment_check(&key, i, version, 0_u64)
+                tree.insert_unchecked(&key, i, version, 0_u64)
                     .unwrap();
             }
         }
@@ -461,7 +461,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in (1..=versions_per_key).rev() {
-                tree.insert_without_version_increment_check(&key, i, version, 0_u64)
+                tree.insert_unchecked(&key, i, version, 0_u64)
                     .unwrap();
             }
         }
@@ -525,7 +525,7 @@ mod tests {
         for i in 0..num_keys {
             let key: FixedSizeKey<16> = i.into();
             for version in 1..=versions_per_key {
-                tree.insert_without_version_increment_check(&key, i, version, 0_u64)
+                tree.insert_unchecked(&key, i, version, 0_u64)
                     .unwrap();
             }
         }
@@ -610,7 +610,7 @@ mod tests {
         let key: FixedSizeKey<16> = 1u16.into();
         let versions = [1, 2];
         for &version in &versions {
-            tree.insert_without_version_increment_check(&key, 1, version, 0_u64)
+            tree.insert_unchecked(&key, 1, version, 0_u64)
                 .unwrap();
         }
 
@@ -654,7 +654,7 @@ mod tests {
         let key: FixedSizeKey<16> = 1u16.into();
         let versions = [1, 2];
         for &version in &versions {
-            tree.insert_without_version_increment_check(&key, 1, version, 0_u64)
+            tree.insert_unchecked(&key, 1, version, 0_u64)
                 .unwrap();
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -208,7 +208,7 @@ impl<K: KeyTrait + Clone, V: Clone> TwigNode<K, V> {
     }
 
     // Implementations of new functions
-    pub fn last_less_than(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
+    pub fn last_less_than_ts(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
         self.values
             .iter()
             .filter(|value| value.ts < ts)
@@ -216,11 +216,11 @@ impl<K: KeyTrait + Clone, V: Clone> TwigNode<K, V> {
             .cloned()
     }
 
-    pub fn last_less_or_equal(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
+    pub fn last_less_or_equal_ts(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
         self.get_leaf_by_ts(ts)
     }
 
-    pub fn first_greater_than(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
+    pub fn first_greater_than_ts(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
         self.values
             .iter()
             .filter(|value| value.ts > ts)
@@ -228,7 +228,7 @@ impl<K: KeyTrait + Clone, V: Clone> TwigNode<K, V> {
             .cloned()
     }
 
-    pub fn first_greater_or_equal(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
+    pub fn first_greater_or_equal_ts(&self, ts: u64) -> Option<Arc<LeafValue<V>>> {
         self.values
             .iter()
             .filter(|value| value.ts >= ts)
@@ -1360,82 +1360,82 @@ mod tests {
     }
 
     #[test]
-    fn test_last_less_than() {
+    fn test_last_less_than_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
         let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
         // Timestamp just below an existing timestamp
-        let leaf = node.last_less_than(20);
+        let leaf = node.last_less_than_ts(20);
         assert_eq!(leaf.unwrap().value, 50);
 
         // Timestamp well below any existing timestamp
-        let leaf = node.last_less_than(5);
+        let leaf = node.last_less_than_ts(5);
         assert!(leaf.is_none());
 
         // Timestamp above all existing timestamps
-        let leaf = node.last_less_than(25);
+        let leaf = node.last_less_than_ts(25);
         assert_eq!(leaf.unwrap().value, 51);
     }
 
     #[test]
-    fn test_last_less_or_equal() {
+    fn test_last_less_or_equal_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
         let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
         // Exact timestamp
-        let leaf = node.last_less_or_equal(10);
+        let leaf = node.last_less_or_equal_ts(10);
         assert_eq!(leaf.unwrap().value, 50);
 
         // Timestamp not present, should get closest lower timestamp
-        let leaf = node.last_less_or_equal(15);
+        let leaf = node.last_less_or_equal_ts(15);
         assert_eq!(leaf.unwrap().value, 50);
 
         // Higher timestamp, should get the highest available timestamp
-        let leaf = node.last_less_or_equal(25);
+        let leaf = node.last_less_or_equal_ts(25);
         assert_eq!(leaf.unwrap().value, 51);
     }
 
     #[test]
-    fn test_first_greater_than() {
+    fn test_first_greater_than_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
         let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
         // Timestamp just above an existing timestamp
-        let leaf = node.first_greater_than(10);
+        let leaf = node.first_greater_than_ts(10);
         assert_eq!(leaf.unwrap().value, 51);
 
         // Timestamp well above any existing timestamp
-        let leaf = node.first_greater_than(25);
+        let leaf = node.first_greater_than_ts(25);
         assert!(leaf.is_none());
 
         // Timestamp below all existing timestamps
-        let leaf = node.first_greater_than(5);
+        let leaf = node.first_greater_than_ts(5);
         assert_eq!(leaf.unwrap().value, 50);
     }
 
     #[test]
-    fn test_first_greater_or_equal() {
+    fn test_first_greater_or_equal_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
         let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
         // Exact timestamp
-        let leaf = node.first_greater_or_equal(10);
+        let leaf = node.first_greater_or_equal_ts(10);
         assert_eq!(leaf.unwrap().value, 50);
 
         // Timestamp not present, should get closest higher timestamp
-        let leaf = node.first_greater_or_equal(15);
+        let leaf = node.first_greater_or_equal_ts(15);
         assert_eq!(leaf.unwrap().value, 51);
 
         // Lower timestamp, should get the lowest available timestamp
-        let leaf = node.first_greater_or_equal(5);
+        let leaf = node.first_greater_or_equal_ts(5);
         assert_eq!(leaf.unwrap().value, 50);
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -7,6 +7,7 @@ use crate::iter::{Iter, Range, VersionedIter};
 use crate::node::Version;
 use crate::{KeyTrait, TrieError};
 
+#[derive(Clone)]
 /// Represents a snapshot of the data within the Trie.
 pub struct Snapshot<P: KeyTrait, V: Clone> {
     pub(crate) ts: u64,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -188,6 +188,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
 
 #[cfg(test)]
 mod tests {
+    use crate::art::QueryType;
     use crate::art::Tree;
     use crate::iter::Iter;
     use crate::KeyTrait;
@@ -550,5 +551,89 @@ mod tests {
         // Scenario 3: Ensure no history for a non-existent key
         let key3 = VariableSizeKey::from_str("non_existent_key").unwrap();
         assert!(snapshot.get_version_history(&key3).is_err());
+    }
+
+    #[test]
+    fn test_latest_by_version() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 1).unwrap();
+        snapshot.insert(&key, 20, 2).unwrap();
+        snapshot.insert(&key, 30, 3).unwrap();
+
+        let query_type = QueryType::LatestByVersion(3);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (30, 1, 3));
+    }
+
+    #[test]
+    fn test_latest_by_ts() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 1).unwrap();
+        snapshot.insert(&key, 20, 2).unwrap();
+        snapshot.insert(&key, 30, 3).unwrap();
+
+        let query_type = QueryType::LatestByTs(300);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (30, 1, 3));
+    }
+
+    #[test]
+    fn test_last_less_than_ts() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 100).unwrap();
+        snapshot.insert(&key, 20, 150).unwrap();
+        snapshot.insert(&key, 30, 300).unwrap();
+
+        let query_type = QueryType::LastLessThanTs(150);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (10, 1, 100));
+    }
+
+    #[test]
+    fn test_last_less_or_equal_ts() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 100).unwrap();
+        snapshot.insert(&key, 20, 150).unwrap();
+        snapshot.insert(&key, 30, 300).unwrap();
+
+        let query_type = QueryType::LastLessOrEqualTs(150);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (20, 1, 150));
+    }
+
+    #[test]
+    fn test_first_greater_than_ts() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 100).unwrap();
+        snapshot.insert(&key, 20, 150).unwrap();
+        snapshot.insert(&key, 30, 300).unwrap();
+
+        let query_type = QueryType::FirstGreaterThanTs(150);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (30, 1, 300));
+    }
+
+    #[test]
+    fn test_first_greater_or_equal_ts() {
+        let tree: Tree<VariableSizeKey, i32> = Tree::new();
+        let mut snapshot = tree.create_snapshot().unwrap();
+        let key = VariableSizeKey::from_str("test_key").unwrap();
+        snapshot.insert(&key, 10, 100).unwrap();
+        snapshot.insert(&key, 20, 150).unwrap();
+        snapshot.insert(&key, 30, 300).unwrap();
+
+        let query_type = QueryType::FirstGreaterOrEqualTs(150);
+        let result = snapshot.get_value_by_query(&key, query_type).unwrap();
+        assert_eq!(result, (20, 1, 150));
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -62,8 +62,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
 
         // Use a recursive function to get the value and timestamp from the root node
         match self.root.as_ref() {
-            Some(root) => Node::get_recurse(root, key, root.version())
-                .map(|(value, version, ts)| (value, version, ts)),
+            Some(root) => Node::get_recurse(root, key, root.version()),
             None => Err(TrieError::KeyNotFound),
         }
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -175,14 +175,12 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         &self,
         key: &P,
         query_type: QueryType,
-    ) -> Result<(V, u64), TrieError> {
+    ) -> Result<(V, u64, u64), TrieError> {
         // Check if the snapshot is already closed
         self.is_closed()?;
 
         match self.root.as_ref() {
-            Some(root) => {
-                Node::get_recurse(root, key, query_type).map(|(value, version, _)| (value, version))
-            }
+            Some(root) => Node::get_recurse(root, key, query_type),
             None => Err(TrieError::KeyNotFound),
         }
     }


### PR DESCRIPTION
## Description

This PR does the following

1) Adds the following versioned APIs to the snapshot and tree
    - `get_at_ts` (to get a key at a particular timestamp)
    - `get_all_versions` (to get all the versions of a key)
    - `scan_at_ts` (scans all keys at a timestamp)
    - `keys_at_ts` (query all keys at a timestamp)
2) Avoid returning the key from all the get APIs
3) Shorten function name `insert_without_version_increment_check` ---> `insert_unchecked`
4) Fix an issue with duplicate insertion (two keys with the same version) into the twig node, where the duplicate node is not sorted by timestamp
5) Add `get_value_by_query` to both tree and snapshot to query the value by the following query types
    - `LatestByVersion`
    - `LatestByTs`
    - `LastLessThanTs`
    - `LastLessOrEqualTs`
    - `FirstGreaterThanTs`
    - `FirstGreaterOrEqualTs`
