### PR TITLE
Return prefixes as slices instead of vectors

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -645,14 +645,13 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
 
         // Determine the prefix of the key after the current depth.
         let key_prefix = key.prefix_after(depth);
-        let key_prefix = key_prefix.as_slice();
         // Find the longest common prefix between the current node's prefix and the key's prefix.
         let longest_common_prefix = cur_node_prefix.longest_common_prefix(key_prefix);
 
         // Create a new key that represents the remaining part of the current node's prefix after the common prefix.
-        let new_key = cur_node_prefix.prefix_after(longest_common_prefix);
+        let new_key = cur_node_prefix.prefix_after(longest_common_prefix).into();
         // Extract the prefix of the current node up to the common prefix.
-        let prefix = cur_node_prefix.prefix_before(longest_common_prefix);
+        let prefix = cur_node_prefix.prefix_before(longest_common_prefix).into();
         // Determine whether the current node's prefix and the key's prefix match up to the common prefix.
         let is_prefix_match = min(cur_node_prefix_len, key_prefix.len()) == longest_common_prefix;
 
@@ -754,7 +753,6 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
 
             // Determine the prefix of the key after the current depth.
             let key_prefix = key.prefix_after(depth);
-            let key_prefix = key_prefix.as_slice();
 
             // Find the longest common prefix between the current node's prefix and the key's prefix.
             let longest_common_prefix = prefix.longest_common_prefix(key_prefix);
@@ -792,7 +790,6 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
 
         loop {
             let key_prefix = key.prefix_after(depth);
-            let key_prefix = key_prefix.as_slice();
             let prefix = cur_node.prefix();
             let lcp = prefix.longest_common_prefix(key_prefix);
 
@@ -1065,8 +1062,8 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
         let (new_root, is_deleted) = match &node {
             Some(root) if !root.is_twig() => {
                 // Determine the prefix of the key after the current depth.
-                let prefix_after = key.prefix_after(0);
-                let key_prefix = prefix_after.as_slice(); // Find the longest common prefix between the current node's prefix and the key's prefix.
+                let key_prefix = key.prefix_after(0);
+                // Find the longest common prefix between the current node's prefix and the key's prefix.
                 let longest_common_prefix = root.prefix().longest_common_prefix(key_prefix);
 
                 if longest_common_prefix != root.prefix().len() {
@@ -1088,8 +1085,8 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
             Some(root) => {
                 // case where the root is a twig.
                 // Determine the prefix of the key after the current depth.
-                let prefix_after = key.prefix_after(0);
-                let key_prefix = prefix_after.as_slice(); // Find the longest common prefix between the current node's prefix and the key's prefix.
+                let key_prefix = key.prefix_after(0);
+                // Find the longest common prefix between the current node's prefix and the key's prefix.
                 let longest_common_prefix = root.prefix().longest_common_prefix(key_prefix);
 
                 if longest_common_prefix != root.prefix().len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use std::str::FromStr;
 pub trait Key {
     fn at(&self, pos: usize) -> u8;
     fn len(&self) -> usize;
-    fn prefix_before(&self, length: usize) -> Self;
-    fn prefix_after(&self, start: usize) -> Self;
+    fn prefix_before(&self, length: usize) -> &[u8];
+    fn prefix_after(&self, start: usize) -> &[u8];
     fn longest_common_prefix(&self, slice: &[u8]) -> usize;
     fn as_slice(&self) -> &[u8];
     fn extend(&self, other: &Self) -> Self;
@@ -28,14 +28,8 @@ pub trait Key {
     }
 }
 
-pub trait KeyTrait:
-    Key + Clone + PartialEq + PartialOrd + Ord + Debug + for<'a> From<&'a [u8]>
-{
-}
-impl<T: Key + Clone + PartialOrd + PartialEq + Ord + Debug + for<'a> From<&'a [u8]>> KeyTrait
-    for T
-{
-}
+pub trait KeyTrait: Key + Clone + Ord + Debug + for<'a> From<&'a [u8]> {}
+impl<T: Key + Clone + Ord + Debug + for<'a> From<&'a [u8]>> KeyTrait for T {}
 
 /*
     Key trait implementations
@@ -119,15 +113,15 @@ impl<const SIZE: usize> Key for FixedSizeKey<SIZE> {
     }
 
     // Creates a new instance of FixedSizeKey consisting only of the initial part of the content
-    fn prefix_before(&self, length: usize) -> Self {
+    fn prefix_before(&self, length: usize) -> &[u8] {
         assert!(length <= self.len);
-        Self::from_slice(&self.content[..length])
+        &self.content[..length]
     }
 
     // Creates a new instance of FixedSizeKey excluding the initial part of the content
-    fn prefix_after(&self, start: usize) -> Self {
+    fn prefix_after(&self, start: usize) -> &[u8] {
         assert!(start <= self.len);
-        Self::from_slice(&self.content[start..self.len])
+        &self.content[start..self.len]
     }
 
     #[inline(always)]
@@ -288,14 +282,14 @@ impl From<&[u8]> for VariableSizeKey {
 }
 
 impl Key for VariableSizeKey {
-    fn prefix_before(&self, length: usize) -> Self {
+    fn prefix_before(&self, length: usize) -> &[u8] {
         assert!(length <= self.data.len());
-        VariableSizeKey::from_slice(&self.data[..length])
+        &self.data[..length]
     }
 
-    fn prefix_after(&self, start: usize) -> Self {
+    fn prefix_after(&self, start: usize) -> &[u8] {
         assert!(start <= self.data.len());
-        VariableSizeKey::from_slice(&self.data[start..self.data.len()])
+        &self.data[start..self.data.len()]
     }
 
     #[inline(always)]


### PR DESCRIPTION
- Make `Key::prefix_after()` return a slice of the original key without any allocation and copying.
- Do the same for `Key:: prefix_before()` for consistency. It's used only in one place, so there's no harm in one extra `.into()`.
- Unrelated, but also simplify `KeyTrait` and its blanket impl by removing unnecessary trait bounds.

In most cases `prefix = key.prefix_after()` is immediately followed by `prefix.as_slice()`, suggesting that there is no need to allocate the intermediate key just to convert it to a slice on the next line. This change improves the performance of gets as shown in the `cargo bench` output below:

<img width="767" alt="Screenshot 2024-07-04 at 15 22 13" src="https://github.com/surrealdb/vart/assets/241037/418a699d-5494-4d5a-8494-b00254d907b7">
