### PR TITLE
Fix: range scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vart"
 publish = true
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/art.rs
+++ b/src/art.rs
@@ -1008,7 +1008,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 
         for kv in kv_pairs {
             let k = kv.key.clone(); // Clone the key
-            // println!("key: {:?} {}", k, kv.version);
+                                    // println!("key: {:?} {}", k, kv.version);
             let v = kv.value.clone(); // Clone the value
             let mut t = kv.version;
 
@@ -1925,7 +1925,7 @@ mod tests {
     fn range_seq_u16() {
         let mut tree: Tree<FixedSizeKey<16>, u16> = Tree::<FixedSizeKey<16>, u16>::new();
 
-        let max = u16::MAX/2;
+        let max = u16::MAX;
         // Insertion
         for i in 0..=max {
             let key: FixedSizeKey<16> = i.into();
@@ -1933,7 +1933,7 @@ mod tests {
         }
 
         let mut len = 0usize;
-        let start_key: FixedSizeKey<16> = 32768u16.into();
+        let start_key: FixedSizeKey<16> = 0u8.into();
         let end_key: FixedSizeKey<16> = max.into();
 
         for _ in tree.range(start_key..=end_key) {

--- a/src/art.rs
+++ b/src/art.rs
@@ -596,7 +596,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             NodeType::Node16(_) => "Node16".to_string(),
             NodeType::Node48(_) => "Node48".to_string(),
             NodeType::Node256(_) => "Node256".to_string(),
-            NodeType::Twig(_) => "twig".to_string(),
+            NodeType::Twig(_) => "Twig".to_string(),
         }
     }
 
@@ -1008,6 +1008,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 
         for kv in kv_pairs {
             let k = kv.key.clone(); // Clone the key
+            // println!("key: {:?} {}", k, kv.version);
             let v = kv.value.clone(); // Clone the value
             let mut t = kv.version;
 
@@ -1924,7 +1925,7 @@ mod tests {
     fn range_seq_u16() {
         let mut tree: Tree<FixedSizeKey<16>, u16> = Tree::<FixedSizeKey<16>, u16>::new();
 
-        let max = u16::MAX;
+        let max = u16::MAX/2;
         // Insertion
         for i in 0..=max {
             let key: FixedSizeKey<16> = i.into();
@@ -1932,7 +1933,7 @@ mod tests {
         }
 
         let mut len = 0usize;
-        let start_key: FixedSizeKey<16> = 0u8.into();
+        let start_key: FixedSizeKey<16> = 32768u16.into();
         let end_key: FixedSizeKey<16> = max.into();
 
         for _ in tree.range(start_key..=end_key) {

--- a/src/art.rs
+++ b/src/art.rs
@@ -1008,7 +1008,6 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 
         for kv in kv_pairs {
             let k = kv.key.clone(); // Clone the key
-                                    // println!("key: {:?} {}", k, kv.version);
             let v = kv.value.clone(); // Clone the value
             let mut t = kv.version;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::{BinaryHeap, Bound, VecDeque};
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -345,7 +344,6 @@ pub struct Range<'a, K: KeyTrait, V: Clone, R> {
     range: R,
     is_versioned: bool,
     prefix: Vec<u8>,
-    level: usize,
     prefix_lengths: Vec<usize>,
 }
 
@@ -360,7 +358,6 @@ where
             range,
             is_versioned: false,
             prefix: Vec::new(),
-            level: 0,
             prefix_lengths: Vec::new(),
         }
     }
@@ -380,7 +377,6 @@ where
             range,
             is_versioned: false,
             prefix,
-            level: 1, // Fix, can only be 1 if not empty
             prefix_lengths: Vec::new(),
         }
     }
@@ -389,18 +385,6 @@ where
     where
         R: RangeBounds<K>,
     {
-        // Self {
-        //     forward: node.map_or_else(ForwardIterState::empty, |n| {
-        //         ForwardIterState::forward_scan(n, &range, true)
-        //     }),
-        //     range,
-        //     is_versioned: true,
-        //     prefix: Vec::new(),
-        //     level: 1, // Fix, can only be 1 if not empty
-        //     prefix_lengths: Vec::new(),
-        // }
-
-
         let forward = node.map_or_else(ForwardIterState::empty, |n| {
             ForwardIterState::forward_scan(n, &range, true)
         });
@@ -410,12 +394,10 @@ where
         Self {
             forward,
             range,
-            is_versioned: false,
+            is_versioned: true,
             prefix,
-            level: 1, // Fix, can only be 1 if not empty
             prefix_lengths: Vec::new(),
         }
-
     }
 }
 
@@ -427,10 +409,7 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
             let e = node.next();
             match e {
                 Some(other) => {
-                    // println!("Node {:?} {:?} {}", other.1.node_type_name(), other.1.prefix(), self.level);
-                    // println!("Node {:?} {}", other.1.node_type_name(),  self.level);
                     if let NodeType::Twig(twig) = &other.1.node_type {
-                        // println!("Twig {:?}", twig.key);
                         if self.range.contains(&twig.key) {
                             // If the query is versioned, iterate over all versions of the key
                             // and add them to the leafs queue. Otherwise, add the latest version.
@@ -450,11 +429,6 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
                             }
                         }
                     } else {
-                        // self.prefix.extend_from_slice(other.1.prefix().as_slice());
-                        // self.level += 1;
-                        // println!("adding iter {:?}", other.1.prefix());
-                        // self.forward.iters.push(NodeIter::new(other.1.iter()));
-
                         // Save the current prefix length before extending
                         let prefix_len_before = self.prefix.len();
                         self.prefix.extend_from_slice(other.1.prefix().as_slice());
@@ -477,10 +451,6 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
                             Bound::Unbounded => &[],
                         };
 
-                        // println!("start_bound_slice {:?}", start_bound_slice);
-                        // println!("end_bound_slice {:?}", end_bound_slice);
-                        // println!("prefix_slice {:?}", prefix_slice);
-
                         // Check if self.prefix is within the start and end bounds
                         let within_start_bound = match self.range.start_bound() {
                             Bound::Included(_) => prefix_slice >= start_bound_slice,
@@ -488,54 +458,23 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
                             Bound::Unbounded => true,
                         };
 
-                        // println!("within_start_bound {:?}", within_start_bound);
-
-                        // let within_end_bound = match self.range.end_bound() {
-                        //     Bound::Included(_) => prefix_slice <= end_bound_slice,
-                        //     Bound::Excluded(_) => prefix_slice < end_bound_slice,
-                        //     Bound::Unbounded => true,
-                        // };
-
                         let within_end_bound = match self.range.end_bound() {
-                            Bound::Included(_) => {
-                                // println!("Checking end bound: prefix_slice <= end_bound_slice");
-                                prefix_slice <= end_bound_slice
-                            },
-                            Bound::Excluded(_) => {
-                                // println!("Checking end bound: prefix_slice < end_bound_slice");
-                                prefix_slice <= end_bound_slice
-                            },
-                            Bound::Unbounded => {
-                                // println!("End bound is unbounded");
-                                true
-                            },
+                            Bound::Included(_) => prefix_slice <= end_bound_slice,
+                            Bound::Excluded(_) => prefix_slice <= end_bound_slice,
+                            Bound::Unbounded => true,
                         };
 
-                        // println!("within_end_bound {:?}", within_end_bound);
-                        // println!("prefix_slice: {:?}, end_bound_slice: {:?}", prefix_slice, end_bound_slice);
-
                         if within_start_bound && within_end_bound {
-                            self.level += 1;
-                            // println!("Level: {}, adding iter {:?}", self.level, other.1.prefix());
                             self.forward.iters.push(NodeIter::new(other.1.iter()));
                             // Push the current prefix length onto the stack
                             self.prefix_lengths.push(prefix_len_before);
                         } else {
-                            // println!("Clearing iters {:?}", self.prefix);
                             // Restore the prefix to its previous state
                             self.prefix.truncate(prefix_len_before);
-                            // println!("Clearing iters {:?}", self.prefix);
-                            // self.forward.iters.pop();
                         }
                     }
                 }
                 None => {
-                    // self.level -= 1;
-                    // println!("Popping iter {:?}", self.prefix);
-                    // self.forward.iters.pop();
-
-                    self.level -= 1;
-                    // println!("Popping iter {:?}", self.prefix);
                     self.forward.iters.pop();
                     // Restore the prefix to its previous state
                     if let Some(prefix_len_before) = self.prefix_lengths.pop() {
@@ -555,103 +494,6 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
         })
     }
 }
-
-// impl<'a, K: KeyTrait, V: Clone, R> Range<'a, K, V, R>
-// where
-//     K: Ord,
-//     R: RangeBounds<K>,
-// {
-//     pub fn range_scan(&self, root: Option<&'a Arc<Node<K, V>>>, start: &[u8], end: &[u8]) -> Vec<(Vec<u8>, String)> {
-//         let mut result = Vec::new();
-//         if let Some(root) = &root {
-//             let mut stack = vec![(root, 0)];
-
-//             while let Some((node, depth)) = stack.pop() {
-
-//                 match node.node_type_name() {
-//                     "Leaf" => {
-//                         if self.is_key_in_range(key, start, end) {
-//                             result.push((key.clone(), value.clone()));
-//                         }
-//                     }
-//                     Node::Leaf { key, value } => {
-//                         if self.is_key_in_range(key, start, end) {
-//                             result.push((key.clone(), value.clone()));
-//                         }
-//                     }
-//                     Node::Node4 { keys, children } |
-//                     Node::Node16 { keys, children } |
-//                     Node::Node48 { keys, children } => {
-//                         for (i, child) in children.iter().enumerate().rev() {
-//                             if let Some(child) = child {
-//                                 if let Some(&key) = keys[i] {
-//                                     if self.should_traverse_child(key, start, end, depth) {
-//                                         stack.push((child, depth + 1));
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                     Node::Node256 { children } => {
-//                         for (i, child) in children.iter().enumerate().rev() {
-//                             if let Some(child) = child {
-//                                 let key = i as u8;
-//                                 if self.should_traverse_child(key, start, end, depth) {
-//                                     stack.push((child, depth + 1));
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             }
-//         }
-//         result.sort_by(|(a, _), (b, _)| a.cmp(b));
-//         result
-//     }
-
-//     fn is_key_in_range(&self, key: &[u8], start: &[u8], end: &[u8]) -> bool {
-//         key >= start && key <= end
-//     }
-
-//     fn should_traverse_child(&self, key: u8, start: &[u8], end: &[u8], depth: usize) -> bool {
-//         if depth >= start.len() || depth >= end.len() {
-//             return true;
-//         }
-
-//         let start_byte = start[depth];
-//         let end_byte = end[depth];
-
-//         if key < start_byte || key > end_byte {
-//             return false;
-//         }
-
-//         if key > start_byte && key < end_byte {
-//             return true;
-//         }
-
-//         if key == start_byte {
-//             return self.compare_remaining(start, depth + 1) != Ordering::Greater;
-//         }
-
-//         if key == end_byte {
-//             return self.compare_remaining(end, depth + 1) != Ordering::Less;
-//         }
-
-//         true
-//     }
-
-//     fn compare_remaining(&self, key: &[u8], depth: usize) -> Ordering {
-//         if depth >= key.len() {
-//             return Ordering::Equal;
-//         }
-
-//         match key[depth] {
-//             0 => Ordering::Less,
-//             255 => Ordering::Greater,
-//             _ => Ordering::Equal,
-//         }
-//     }
-// }
 
 pub(crate) fn scan_node<K, V, R>(
     node: Option<&Arc<Node<K, V>>>,
@@ -755,7 +597,7 @@ mod tests {
     use std::str::FromStr;
 
     use crate::art::Tree;
-    use crate::KeyTrait;
+
     use crate::VariableSizeKey;
     use crate::{FixedSizeKey, Key};
 
@@ -1097,7 +939,6 @@ mod tests {
         assert_eq!(expected, fwd);
     }
 
-
     fn setup_trie() -> Tree<VariableSizeKey, u16> {
         let mut tree: Tree<VariableSizeKey, u16> = Tree::<VariableSizeKey, u16>::new();
         let words = vec![
@@ -1119,7 +960,7 @@ mod tests {
         }
 
         tree
-    }    
+    }
 
     #[test]
     fn test_range_scan_full_range() {
@@ -1129,20 +970,20 @@ mod tests {
         let results: Vec<_> = trie.range(range).collect();
 
         let expected = vec![
-            (b"apple".to_vec(), &1, &0, &0),
-            (b"apricot".to_vec(), &2, &0, &0),
-            (b"banana".to_vec(), &3, &0, &0),
-            (b"blackberry".to_vec(), &4, &0, &0),
-            (b"blueberry".to_vec(), &5, &0, &0),
-            (b"cherry".to_vec(), &6, &0, &0),
-            (b"date".to_vec(), &7, &0, &0),
-            (b"fig".to_vec(), &8, &0, &0),
-            (b"grape".to_vec(), &9, &0, &0),
-            (b"kiwi".to_vec(), &10, &0, &0),
+            // (b"apple".to_vec(), &1, &0, &0),
+            // (b"apricot".to_vec(), &2, &0, &0),
+            // (b"banana".to_vec(), &3, &0, &0),
+            (b"blackberry\0".to_vec(), &4, &4, &0),
+            (b"blueberry\0".to_vec(), &5, &5, &0),
+            (b"cherry\0".to_vec(), &6, &6, &0),
+            (b"date\0".to_vec(), &7, &7, &0),
+            (b"fig\0".to_vec(), &8, &8, &0),
+            (b"grape\0".to_vec(), &9, &9, &0),
+            (b"kiwi\0".to_vec(), &10, &10, &0),
         ];
 
         println!("{} {:?}", results.len(), results);
-        // assert_eq!(result, expected);
+        assert_eq!(results, expected);
     }
 
     fn setup_btree() -> BTreeMap<Vec<u8>, i32> {
@@ -1171,54 +1012,102 @@ mod tests {
     fn test_range_scan_btree_full_range() {
         let btree = setup_btree();
         let range = b"berry".to_vec()..=b"kiwi".to_vec();
-        let results: Vec<_> = btree.range(range).collect();
+        let results: Vec<_> = btree.range(range).map(|(k, v)| (k.clone(), *v)).collect();
 
         let expected = vec![
-            (b"blackberry".to_vec(), &4),
-            (b"blueberry".to_vec(), &5),
-            (b"cherry".to_vec(), &6),
-            (b"date".to_vec(), &7),
-            (b"fig".to_vec(), &8),
-            (b"grape".to_vec(), &9),
-            (b"kiwi".to_vec(), &10),
+            (b"blackberry".to_vec(), 4),
+            (b"blueberry".to_vec(), 5),
+            (b"cherry".to_vec(), 6),
+            (b"date".to_vec(), 7),
+            (b"fig".to_vec(), 8),
+            (b"grape".to_vec(), 9),
+            (b"kiwi".to_vec(), 10),
         ];
 
-        println!("BTree results: {} {:?}", results.len(), results);
-        // assert_eq!(results, expected);
+        assert_eq!(results, expected);
     }
-
 
     fn setup_trie2() -> Tree<VariableSizeKey, u16> {
         let mut tree: Tree<VariableSizeKey, u16> = Tree::<VariableSizeKey, u16>::new();
         let keys = vec![
-            VariableSizeKey::from_slice(&vec![47, 33, 110, 115, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 33, 100, 98, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 33, 116, 98, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 98, 57, 110, 115, 54, 112, 109, 115, 97, 51, 115, 98, 115, 112, 48, 104, 106, 110, 122, 119, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 103, 112, 52, 54, 108, 51, 105, 50, 99, 106, 53, 55, 119, 106, 97, 52, 107, 49, 56, 103, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 54, 101, 110, 105, 114, 119, 114, 109, 99, 113, 119, 100, 105, 50, 120, 106, 100, 56, 113, 104, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 101, 104, 107, 49, 56, 98, 112, 55, 109, 110, 53, 52, 112, 102, 114, 120, 49, 53, 50, 51, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 121, 99, 97, 100, 103, 116, 101, 53, 122, 49, 117, 117, 99, 52, 50, 52, 110, 105, 113, 119, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 118, 53, 56, 51, 114, 107, 99, 100, 57, 108, 50, 116, 109, 108, 57, 109, 115, 55, 111, 57, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 102, 121, 108, 104, 53, 97, 48, 99, 121, 57, 107, 104, 107, 118, 99, 50, 110, 107, 121, 103, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 117, 103, 104, 105, 116, 121, 117, 97, 112, 48, 102, 108, 109, 114, 115, 115, 118, 104, 121, 102, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 109, 107, 108, 102, 53, 106, 50, 57, 121, 116, 98, 98, 111, 52, 57, 55, 104, 108, 104, 113, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 117, 102, 104, 49, 111, 98, 113, 100, 108, 116, 110, 106, 52, 108, 114, 116, 53, 57, 121, 52, 0, 0]),
+            VariableSizeKey::from_slice(&[47, 33, 110, 115, 116, 101, 115, 116, 0, 0]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 33, 100, 98, 116, 101, 115, 116, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 33, 116, 98, 116, 101,
+                115, 116, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 98, 57, 110, 115, 54, 112, 109, 115, 97, 51, 115, 98, 115, 112,
+                48, 104, 106, 110, 122, 119, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 103, 112, 52, 54, 108, 51, 105, 50, 99, 106, 53, 55, 119, 106,
+                97, 52, 107, 49, 56, 103, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 54, 101, 110, 105, 114, 119, 114, 109, 99, 113, 119, 100, 105,
+                50, 120, 106, 100, 56, 113, 104, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 101, 104, 107, 49, 56, 98, 112, 55, 109, 110, 53, 52, 112, 102,
+                114, 120, 49, 53, 50, 51, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 121, 99, 97, 100, 103, 116, 101, 53, 122, 49, 117, 117, 99, 52,
+                50, 52, 110, 105, 113, 119, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 118, 53, 56, 51, 114, 107, 99, 100, 57, 108, 50, 116, 109, 108,
+                57, 109, 115, 55, 111, 57, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 102, 121, 108, 104, 53, 97, 48, 99, 121, 57, 107, 104, 107, 118,
+                99, 50, 110, 107, 121, 103, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 117, 103, 104, 105, 116, 121, 117, 97, 112, 48, 102, 108, 109,
+                114, 115, 115, 118, 104, 121, 102, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 109, 107, 108, 102, 53, 106, 50, 57, 121, 116, 98, 98, 111, 52,
+                57, 55, 104, 108, 104, 113, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 117, 102, 104, 49, 111, 98, 113, 100, 108, 116, 110, 106, 52,
+                108, 114, 116, 53, 57, 121, 52, 0, 0,
+            ]),
         ];
-    
+
         for key in keys {
             tree.insert(&key, 1, 0, 0).unwrap();
         }
 
         tree
-    }    
+    }
 
     #[test]
     fn test_range_skv_range() {
         let trie = setup_trie2();
-        let range = 
-        VariableSizeKey::from_slice(&[47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0])
-            ..VariableSizeKey::from_slice(&[47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 255, 0]);
+        let range = VariableSizeKey::from_slice(&[
+            47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0,
+            42, 0, 0,
+        ])
+            ..VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 255, 0,
+            ]);
         let results: Vec<_> = trie.range(range).collect();
 
         println!("{} {:?}", results.len(), results);
@@ -1228,38 +1117,87 @@ mod tests {
     fn setup_btreemap() -> BTreeMap<VariableSizeKey, u16> {
         let mut map: BTreeMap<VariableSizeKey, u16> = BTreeMap::new();
         let keys = vec![
-            VariableSizeKey::from_slice(&vec![47, 33, 110, 115, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 33, 100, 98, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 33, 116, 98, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 98, 57, 110, 115, 54, 112, 109, 115, 97, 51, 115, 98, 115, 112, 48, 104, 106, 110, 122, 119, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 103, 112, 52, 54, 108, 51, 105, 50, 99, 106, 53, 55, 119, 106, 97, 52, 107, 49, 56, 103, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 54, 101, 110, 105, 114, 119, 114, 109, 99, 113, 119, 100, 105, 50, 120, 106, 100, 56, 113, 104, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 101, 104, 107, 49, 56, 98, 112, 55, 109, 110, 53, 52, 112, 102, 114, 120, 49, 53, 50, 51, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 121, 99, 97, 100, 103, 116, 101, 53, 122, 49, 117, 117, 99, 52, 50, 52, 110, 105, 113, 119, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 118, 53, 56, 51, 114, 107, 99, 100, 57, 108, 50, 116, 109, 108, 57, 109, 115, 55, 111, 57, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 102, 121, 108, 104, 53, 97, 48, 99, 121, 57, 107, 104, 107, 118, 99, 50, 110, 107, 121, 103, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 117, 103, 104, 105, 116, 121, 117, 97, 112, 48, 102, 108, 109, 114, 115, 115, 118, 104, 121, 102, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 109, 107, 108, 102, 53, 106, 50, 57, 121, 116, 98, 98, 111, 52, 57, 55, 104, 108, 104, 113, 0, 0]),
-            VariableSizeKey::from_slice(&vec![47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0, 0, 1, 117, 102, 104, 49, 111, 98, 113, 100, 108, 116, 110, 106, 52, 108, 114, 116, 53, 57, 121, 52, 0, 0]),
+            VariableSizeKey::from_slice(&[47, 33, 110, 115, 116, 101, 115, 116, 0, 0]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 33, 100, 98, 116, 101, 115, 116, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 33, 116, 98, 116, 101,
+                115, 116, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 98, 57, 110, 115, 54, 112, 109, 115, 97, 51, 115, 98, 115, 112,
+                48, 104, 106, 110, 122, 119, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 103, 112, 52, 54, 108, 51, 105, 50, 99, 106, 53, 55, 119, 106,
+                97, 52, 107, 49, 56, 103, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 54, 101, 110, 105, 114, 119, 114, 109, 99, 113, 119, 100, 105,
+                50, 120, 106, 100, 56, 113, 104, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 101, 104, 107, 49, 56, 98, 112, 55, 109, 110, 53, 52, 112, 102,
+                114, 120, 49, 53, 50, 51, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 121, 99, 97, 100, 103, 116, 101, 53, 122, 49, 117, 117, 99, 52,
+                50, 52, 110, 105, 113, 119, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 118, 53, 56, 51, 114, 107, 99, 100, 57, 108, 50, 116, 109, 108,
+                57, 109, 115, 55, 111, 57, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 102, 121, 108, 104, 53, 97, 48, 99, 121, 57, 107, 104, 107, 118,
+                99, 50, 110, 107, 121, 103, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 117, 103, 104, 105, 116, 121, 117, 97, 112, 48, 102, 108, 109,
+                114, 115, 115, 118, 104, 121, 102, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 109, 107, 108, 102, 53, 106, 50, 57, 121, 116, 98, 98, 111, 52,
+                57, 55, 104, 108, 104, 113, 0, 0,
+            ]),
+            VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 0, 0, 0, 1, 117, 102, 104, 49, 111, 98, 113, 100, 108, 116, 110, 106, 52,
+                108, 114, 116, 53, 57, 121, 52, 0, 0,
+            ]),
         ];
-    
+
         for key in keys {
             map.insert(key, 1);
         }
-    
+
         map
     }
-    
+
     #[test]
     fn test_range_btreemap() {
         let map = setup_btreemap();
-        let range = 
-        VariableSizeKey::from_slice(&[47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 0, 0])
-            ..VariableSizeKey::from_slice(&[47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 255, 0]);
+        let range = VariableSizeKey::from_slice(&[
+            47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0,
+            42, 0, 0,
+        ])
+            ..VariableSizeKey::from_slice(&[
+                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
+                0, 42, 255, 0,
+            ]);
         let results: Vec<_> = map.range(range).collect();
-    
+
         println!("{} {:?}", results.len(), results);
         // assert_eq!(result, expected);
     }
-
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1153,12 +1153,11 @@ mod tests {
             ("grape", "grapefruit"), // Overlapping range with close keys
             ("a", "b"),              // Minute alphabet range
             ("a", "m"),              // Large alphabet range
-            ("0", "9"),              // Numeric range
             ("a", "a"),              // Single character range
             ("apple", "applf"),      // Overlapping range with close keys
             ("kiwi", "kiwz"),        // Overlapping range with close keys
             ("apple", "applz"),      // Overlapping range with close keys
-            ("a", "aa"),             // Minute alphabet range
+            ("a", "aa"),             // Small alphabet range
             ("a", "az"),             // Large alphabet range
             ("m", "z"),              // Large alphabet range
             ("apple", "applea"),     // Single element range with non-existent key

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1221,64 +1221,19 @@ mod tests {
         let mut tree: Tree<VariableSizeKey, u16> = Tree::<VariableSizeKey, u16>::new();
         let mut map: BTreeMap<VariableSizeKey, u16> = BTreeMap::new();
         let keys = vec![
-            VariableSizeKey::from_slice(&[47, 33, 110, 115, 116, 101, 115, 116, 0, 0]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 33, 100, 98, 116, 101, 115, 116, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 33, 116, 98, 116, 101,
-                115, 116, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 98, 57, 110, 115, 54, 112, 109, 115, 97, 51, 115, 98, 115, 112,
-                48, 104, 106, 110, 122, 119, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 103, 112, 52, 54, 108, 51, 105, 50, 99, 106, 53, 55, 119, 106,
-                97, 52, 107, 49, 56, 103, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 54, 101, 110, 105, 114, 119, 114, 109, 99, 113, 119, 100, 105,
-                50, 120, 106, 100, 56, 113, 104, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 101, 104, 107, 49, 56, 98, 112, 55, 109, 110, 53, 52, 112, 102,
-                114, 120, 49, 53, 50, 51, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 121, 99, 97, 100, 103, 116, 101, 53, 122, 49, 117, 117, 99, 52,
-                50, 52, 110, 105, 113, 119, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 118, 53, 56, 51, 114, 107, 99, 100, 57, 108, 50, 116, 109, 108,
-                57, 109, 115, 55, 111, 57, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 102, 121, 108, 104, 53, 97, 48, 99, 121, 57, 107, 104, 107, 118,
-                99, 50, 110, 107, 121, 103, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 117, 103, 104, 105, 116, 121, 117, 97, 112, 48, 102, 108, 109,
-                114, 115, 115, 118, 104, 121, 102, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 109, 107, 108, 102, 53, 106, 50, 57, 121, 116, 98, 98, 111, 52,
-                57, 55, 104, 108, 104, 113, 0, 0,
-            ]),
-            VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 0, 0, 0, 1, 117, 102, 104, 49, 111, 98, 113, 100, 108, 116, 110, 106, 52,
-                108, 114, 116, 53, 57, 121, 52, 0, 0,
-            ]),
+            VariableSizeKey::from_string(&"/!nstest".to_string()),
+            VariableSizeKey::from_string(&"/*test!dbtest".to_string()),
+            VariableSizeKey::from_string(&"/*test*test!tbtest".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*b9ns6pmsa3sbsp0hjnzw".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*gp46l3i2cj57wja4k18g".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*6enirwrmcqwdi2xjd8qh".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*ehk18bp7mn54pfrx1523".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*ycadgte5z1uuc424niqw".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*v583rkcd9l2tml9ms7o9".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*fylh5a0cy9khkvc2nkyg".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*ughityuap0flmrssvhyf".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*mklf5j29ytbbo497hlhq".to_string()),
+            VariableSizeKey::from_string(&"/*test*test*test*ufh1obqdltnj4lrt59y4".to_string()),
         ];
 
         for key in &keys {
@@ -1295,14 +1250,9 @@ mod tests {
     #[test]
     fn test_trie_vs_btreemap_range_scan_in_sdb_insert() {
         let (trie, map) = setup_trie_and_btreemap();
-        let range = VariableSizeKey::from_slice(&[
-            47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0,
-            42, 0, 0,
-        ])
-            ..VariableSizeKey::from_slice(&[
-                47, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116, 0, 42, 116, 101, 115, 116,
-                0, 42, 255, 0,
-            ]);
+        let range = VariableSizeKey::from_string(&"/*test*test*test*".to_string())
+            ..VariableSizeKey::from_string(&"/*test*test*test*�".to_string());
+
         let trie_results: Vec<_> = trie.range(range.clone()).collect();
         let map_results: Vec<_> = map.range(range).collect();
 


### PR DESCRIPTION
## Description

Range scans are extremely slow because there is no check whilst iterating to see if the prefix falls within the specified range bound. Currently, for any range scan, the entire set of keys are read, which makes it extremely slow. This PR attempts to fixe it by introducing bound checks during the DFS on range scan.