### PR TITLE
perf: remove old value lookup on insert

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -986,12 +986,10 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
         let mut new_version = 0;
 
         for kv in kv_pairs {
-            let k = kv.key.clone(); // Clone the key
-            let v = kv.value.clone(); // Clone the value
             let mut t = kv.version;
 
             if t == 0 {
-                // Zero-valued timestamps are associated with current time plus one
+                // Zero-valued versions are associated with current version plus one
                 t = curr_version + 1;
             } else if check_version && (curr_version >= kv.version) {
                 return Err(TrieError::VersionIsOld);
@@ -999,8 +997,8 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 
             // Create a new KV instance
             let new_kv = KV {
-                key: k,
-                value: v,
+                key: &kv.key,
+                value: kv.value.clone(),
                 version: t,
                 ts: kv.ts,
             };
@@ -1019,7 +1017,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
                 Some(root) => {
                     let new_node = Node::insert_recurse(
                         root,
-                        &new_kv.key,
+                        new_kv.key,
                         new_kv.value,
                         new_kv.version,
                         new_kv.ts,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -25,7 +25,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         // Insert the key-value pair into the root node using a recursive function
         match &self.root {
             Some(root) => {
-                let (new_node, _) = Node::insert_recurse(root, key, value, self.ts, ts, 0);
+                let new_node = Node::insert_recurse(root, key, value, self.ts, ts, 0);
                 // Update the root node with the new node after insertion
                 self.root = Some(new_node);
             }


### PR DESCRIPTION
## Description

Each insert operation currently fetches the old record from the twig node to present the old value, which is not used in SurrealKV or elsewhere. This PR eliminates this check, which can lead to performance improvements if there are multiple versions on the twig node.