### PR TITLE
Remove bulk insert and allow inserting equal versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vart"
 publish = true
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Relax little bit the versioned guarantees of `Tree::insert` by allowing values with the versions equal to the root. This allows us to remove `Tree::bulk_insert`, because now the normal `Tree::insert` can be used in the most common path in SurrealKV when writing committed entries.

Tested with SurrealKV and SurrealDB.