### PR TITLE
Perf: avoid twig node keys

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -115,9 +115,9 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
     /// Returns a new `Node` instance with a Twig node containing the provided key, value, and version.
     ///
     #[inline]
-    pub(crate) fn new_twig(prefix: P, key: P, value: V, version: u64, ts: u64) -> Node<P, V> {
+    pub(crate) fn new_twig(prefix: P, value: V, version: u64, ts: u64) -> Node<P, V> {
         // Create a new TwigNode instance using the provided prefix and key.
-        let mut twig = TwigNode::new(prefix, key);
+        let mut twig = TwigNode::new(prefix);
 
         // Insert the provided value into the TwigNode along with the version.
         twig.insert_mut(value, version, ts);
@@ -676,7 +676,6 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             let k2 = key_prefix[longest_common_prefix];
             let new_twig = Node::new_twig(
                 key_prefix[longest_common_prefix..].into(),
-                key.as_slice().into(),
                 value,
                 commit_version,
                 ts,
@@ -704,7 +703,6 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
         // If no child exists for the key's character, create a new Twig node and add it as a child.
         let new_twig = Node::new_twig(
             key_prefix[longest_common_prefix..].into(),
-            key.as_slice().into(),
             value,
             commit_version,
             ts,
@@ -900,7 +898,6 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
             None => {
                 let commit_version = if version == 0 { 1 } else { version };
                 Arc::new(Node::new_twig(
-                    key.as_slice().into(),
                     key.as_slice().into(),
                     value,
                     commit_version,

--- a/src/art.rs
+++ b/src/art.rs
@@ -2307,7 +2307,7 @@ mod tests {
         let mut inserted_data = Vec::new();
 
         // Generate and insert random keys with versions
-        for version in 1u64..=100 {
+        for version in 1u64..=1000 {
             let random_key: String = (0..10).map(|_| rng.sample(Alphanumeric) as char).collect();
             let key = VariableSizeKey::from_str(&random_key).unwrap();
             let value = rng.gen_range(1..100);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -121,6 +121,10 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iterator for Iter<'a, P, V> {
             match e {
                 None => {
                     self.forward.iters.pop();
+                    // Restore the prefix to its previous state
+                    if let Some(prefix_len_before) = self.prefix_lengths.pop() {
+                        self.prefix.truncate(prefix_len_before);
+                    }
                 }
                 Some(other) => {
                     let key: P = self
@@ -141,7 +145,10 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iterator for Iter<'a, P, V> {
                         }
                         break;
                     } else {
+                        let prefix_len_before = self.prefix.len();
+                        self.prefix.extend_from_slice(other.1.prefix().as_slice());
                         self.forward.iters.push(NodeIter::new(other.1.iter()));
+                        self.prefix_lengths.push(prefix_len_before);
                     }
                 }
             }

--- a/src/node.rs
+++ b/src/node.rs
@@ -23,7 +23,6 @@ pub trait Version {
 #[derive(Clone)]
 pub struct TwigNode<K: KeyTrait, V: Clone> {
     pub(crate) prefix: K,
-    pub(crate) key: K,
     pub(crate) values: Vec<Arc<LeafValue<V>>>,
     pub(crate) version: u64, // Version for the twig node
 }
@@ -50,10 +49,9 @@ impl<V: Clone> LeafValue<V> {
 }
 
 impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
-    pub fn new(prefix: K, key: K) -> Self {
+    pub fn new(prefix: K) -> Self {
         TwigNode {
             prefix,
-            key,
             values: Vec::new(),
             version: 0,
         }
@@ -113,7 +111,6 @@ impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
 
         TwigNode {
             prefix: self.prefix.clone(),
-            key: self.key.clone(),
             values: new_values,
             version: new_version,
         }
@@ -1142,17 +1139,13 @@ mod tests {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
         // Prepare some child nodes
-        let mut twig1 =
-            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+        let mut twig1 = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone());
         twig1.version = 5;
-        let mut twig2 =
-            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+        let mut twig2 = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone());
         twig2.version = 10;
-        let mut twig3 =
-            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+        let mut twig3 = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone());
         twig3.version = 3;
-        let mut twig4 =
-            TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix.clone());
+        let mut twig4 = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone());
         twig4.version = 7;
 
         let mut parent = FlatNode {
@@ -1177,7 +1170,7 @@ mod tests {
     fn twig_insert() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
-        let node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
 
         let new_node = node.insert(42, 123, 0);
         assert_eq!(node.values.len(), 0);
@@ -1190,7 +1183,7 @@ mod tests {
     fn twig_insert_mut() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
 
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
 
         node.insert_mut(42, 123, 0);
         assert_eq!(node.values.len(), 1);
@@ -1201,7 +1194,7 @@ mod tests {
     #[test]
     fn twig_get_latest_leaf() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let latest_leaf = node.get_latest_leaf();
@@ -1211,7 +1204,7 @@ mod tests {
     #[test]
     fn twig_get_latest_value() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let latest_value = node.get_latest_value();
@@ -1221,7 +1214,7 @@ mod tests {
     #[test]
     fn twig_get_leaf_by_version() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let leaf = node.get_leaf_by_version(123);
@@ -1233,7 +1226,7 @@ mod tests {
     #[test]
     fn twig_iter() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("foo".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(42, 123, 0);
         node.insert_mut(43, 124, 1);
         let mut iter = node.iter();
@@ -1311,7 +1304,7 @@ mod tests {
     #[test]
     fn twig_get_leaf_by_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         // Inserting leaves with different timestamps
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
@@ -1332,7 +1325,7 @@ mod tests {
     #[test]
     fn test_get_leaf_by_version() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1352,7 +1345,7 @@ mod tests {
     #[test]
     fn test_get_leaf_by_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1372,7 +1365,7 @@ mod tests {
     #[test]
     fn test_get_all_versions() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1385,7 +1378,7 @@ mod tests {
     #[test]
     fn test_last_less_than_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1405,7 +1398,7 @@ mod tests {
     #[test]
     fn test_last_less_or_equal_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1425,7 +1418,7 @@ mod tests {
     #[test]
     fn test_first_greater_than_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 
@@ -1445,7 +1438,7 @@ mod tests {
     #[test]
     fn test_first_greater_or_equal_ts() {
         let dummy_prefix: FixedSizeKey<8> = FixedSizeKey::create_key("bar".as_bytes());
-        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix.clone(), dummy_prefix);
+        let mut node = TwigNode::<FixedSizeKey<8>, usize>::new(dummy_prefix);
         node.insert_mut(50, 200, 10); // value: 50, version: 200, timestamp: 10
         node.insert_mut(51, 201, 20); // value: 51, version: 201, timestamp: 20
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -32,7 +32,6 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
             None => {
                 self.root = Some(Arc::new(Node::new_twig(
                     key.as_slice().into(),
-                    key.as_slice().into(),
                     value,
                     self.ts,
                     ts,


### PR DESCRIPTION
## Description

1) Removes the dependency of key from the twig node. It can be constructed during iter/range scans using depth first search.
2) Removes backward iterator method, as it is not useful currently.

## Criteria to merge

1) Check with benchmarks if this PR improves memory usage
2) Add Fuzz tests
