### PR TITLE
perf: add inlining for range/iter and benchmark

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -105,6 +105,7 @@ impl<'a, P: KeyTrait + 'a, V: Clone> Iter<'a, P, V> {
 impl<'a, P: KeyTrait + 'a, V: Clone> Iterator for Iter<'a, P, V> {
     type Item = (Vec<u8>, &'a V, &'a u64, &'a u64);
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(node) = self.forward.iters.last_mut() {
             let e = node.next();
@@ -493,6 +494,7 @@ where
 impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K, V, R> {
     type Item = (Vec<u8>, &'a V, &'a u64, &'a u64);
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(node) = self.forward.iters.last_mut() {
             if let Some(other) = node.next() {


### PR DESCRIPTION
## Description

This PR adds method inlining for the next method in Iter/Range methods. Also adds benchmark to measure the improvements.

## Performance

without inlining

```
iter_benchmark/art/1000000
                        time:   [25.493 ms 25.539 ms 25.588 ms]
                        thrpt:  [39.081  elem/s 39.156  elem/s 39.226  elem/s]

range_benchmark/art/1000000
                        time:   [32.368 ms 32.672 ms 33.110 ms]
                        thrpt:  [30.202  elem/s 30.608  elem/s 30.895  elem/s]

```

with inlining

```
iter_benchmark/art/1000000
                        time:   [5.5269 ms 5.8293 ms 6.3694 ms]
                        thrpt:  [157.00  elem/s 171.55  elem/s 180.93  elem/s]
                 change:
                        time:   [-78.351% -77.175% -75.171%] (p = 0.00 < 0.05)
                        thrpt:  [+302.76% +338.12% +361.92%]
                        Performance has improved.

range_benchmark/art/1000000
                        time:   [11.827 ms 12.020 ms 12.324 ms]
                        thrpt:  [81.140  elem/s 83.197  elem/s 84.550  elem/s]
                 change:
                        time:   [-64.018% -63.211% -62.327%] (p = 0.00 < 0.05)
                        thrpt:  [+165.44% +171.82% +177.91%]
                        Performance has improved.
```