### PR TITLE
perf: make insert_unchecked mutable to avoid cow

### DIFF
--- a/benches/vart_bench.rs
+++ b/benches/vart_bench.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -39,6 +40,16 @@ pub fn seq_insert_mut(c: &mut Criterion) {
         })
     });
 
+    // Benchmark for BTreeMap
+    group.bench_function("btreemap", |b| {
+        let mut btree = BTreeMap::new();
+        let mut key = 0u64;
+        b.iter(|| {
+            btree.insert(key, key);
+            key += 1;
+        })
+    });
+
     group.finish();
 }
 
@@ -72,6 +83,16 @@ pub fn rand_insert_mut(c: &mut Criterion) {
         b.iter(|| {
             let key = &keys[rng.gen_range(0..keys.len())];
             let _ = tree.insert_unchecked(&key.into(), key.clone(), 0, 0);
+        })
+    });
+
+    // Benchmark for BTreeMap
+    group.bench_function("btreemap", |b| {
+        let mut btree = BTreeMap::new();
+        let mut rng = seeded_rng(0xE080D1A42C207DAF);
+        b.iter(|| {
+            let key = &keys[rng.gen_range(0..keys.len())];
+            btree.insert(key.clone(), key.clone());
         })
     });
 
@@ -270,8 +291,8 @@ criterion_group!(iter_benches, iter_benchmark);
 criterion_group!(range_benches, range_benchmark);
 criterion_main!(
     insert_benches,
-    // read_benches,
-    // delete_benches,
-    // iter_benches,
-    // range_benches
+    read_benches,
+    delete_benches,
+    iter_benches,
+    range_benches
 );

--- a/src/art.rs
+++ b/src/art.rs
@@ -254,7 +254,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
                 // Create a new Node instance with the updated NodeType.
                 Self { node_type: node }
             }
-            NodeType::Twig(_) => panic!("Unexpected Twig node encountered in add_child()"),
+            NodeType::Twig(_) => panic!("Unexpected Twig node encountered in add_child_mut()"),
         }
     }
 
@@ -678,6 +678,36 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
         }
     }
 
+    // Common logic for insert to extract common prefix and key prefix
+    fn common_insert_logic<'a>(
+        cur_node_prefix: &P,
+        key: &'a P,
+        depth: usize,
+    ) -> (&'a [u8], P, P, bool, usize) {
+        // Obtain the current node's prefix and its length.
+        let cur_node_prefix_len = cur_node_prefix.len();
+
+        // Determine the prefix of the key after the current depth.
+        let key_prefix = key.prefix_after(depth);
+        // Find the longest common prefix between the current node's prefix and the key's prefix.
+        let longest_common_prefix = cur_node_prefix.longest_common_prefix(key_prefix);
+
+        // Create a new key that represents the remaining part of the current node's prefix after the common prefix.
+        let new_key = cur_node_prefix.prefix_after(longest_common_prefix).into();
+        // Extract the prefix of the current node up to the common prefix.
+        let prefix = cur_node_prefix.prefix_before(longest_common_prefix).into();
+        // Determine whether the current node's prefix and the key's prefix match up to the common prefix.
+        let is_prefix_match = min(cur_node_prefix_len, key_prefix.len()) == longest_common_prefix;
+
+        (
+            key_prefix,
+            new_key,
+            prefix,
+            is_prefix_match,
+            longest_common_prefix,
+        )
+    }
+
     /// Inserts a key-value pair recursively into the node.
     ///
     /// Recursively inserts a key-value pair into the current node and its child nodes.
@@ -704,19 +734,9 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
     ) -> NodeArc<P, V> {
         // Obtain the current node's prefix and its length.
         let cur_node_prefix = cur_node.prefix().clone();
-        let cur_node_prefix_len = cur_node.prefix().len();
 
-        // Determine the prefix of the key after the current depth.
-        let key_prefix = key.prefix_after(depth);
-        // Find the longest common prefix between the current node's prefix and the key's prefix.
-        let longest_common_prefix = cur_node_prefix.longest_common_prefix(key_prefix);
-
-        // Create a new key that represents the remaining part of the current node's prefix after the common prefix.
-        let new_key = cur_node_prefix.prefix_after(longest_common_prefix).into();
-        // Extract the prefix of the current node up to the common prefix.
-        let prefix = cur_node_prefix.prefix_before(longest_common_prefix).into();
-        // Determine whether the current node's prefix and the key's prefix match up to the common prefix.
-        let is_prefix_match = min(cur_node_prefix_len, key_prefix.len()) == longest_common_prefix;
+        let (key_prefix, new_key, prefix, is_prefix_match, longest_common_prefix) =
+            Self::common_insert_logic(&cur_node_prefix, key, depth);
 
         // If the current node is a Twig node and the prefixes match up to the end of both prefixes,
         // update the existing value in the Twig node.
@@ -788,19 +808,9 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
     ) {
         // Obtain the current node's prefix and its length.
         let cur_node_prefix = cur_node.prefix().clone();
-        let cur_node_prefix_len = cur_node.prefix().len();
 
-        // Determine the prefix of the key after the current depth.
-        let key_prefix = key.prefix_after(depth);
-        // Find the longest common prefix between the current node's prefix and the key's prefix.
-        let longest_common_prefix = cur_node_prefix.longest_common_prefix(key_prefix);
-
-        // Create a new key that represents the remaining part of the current node's prefix after the common prefix.
-        let new_key = cur_node_prefix.prefix_after(longest_common_prefix).into();
-        // Extract the prefix of the current node up to the common prefix.
-        let prefix = cur_node_prefix.prefix_before(longest_common_prefix).into();
-        // Determine whether the current node's prefix and the key's prefix match up to the common prefix.
-        let is_prefix_match = min(cur_node_prefix_len, key_prefix.len()) == longest_common_prefix;
+        let (key_prefix, new_key, prefix, is_prefix_match, longest_common_prefix) =
+            Self::common_insert_logic(&cur_node_prefix, key, depth);
 
         // If the current node is a Twig node and the prefixes match up to the end of both prefixes,
         // update the existing value in the Twig node.

--- a/src/art.rs
+++ b/src/art.rs
@@ -2334,6 +2334,8 @@ mod tests {
             actual_entries, expected_entries,
             "The number of entries in the tree does not match the expected number of insertions."
         );
+
+        assert_eq!(tree.version(), num_keys as u64);
     }
 
     #[test]
@@ -2352,6 +2354,8 @@ mod tests {
             total_entries, num_keys,
             "The total entries should be equal to the number of inserted keys."
         );
+
+        assert_eq!(tree.version(), { num_keys });
     }
 
     #[test]
@@ -2373,6 +2377,8 @@ mod tests {
         let (value, version, _) = tree.get(&key, 0).unwrap();
         assert_eq!(value, 2);
         assert_eq!(version, 2);
+
+        assert_eq!(tree.version(), 2);
     }
 
     #[test]
@@ -2612,6 +2618,7 @@ mod tests {
         let query_type = QueryType::LatestByVersion(3);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (30, 3, 300));
+        assert_eq!(tree.version(), 3);
     }
 
     #[test]
@@ -2625,6 +2632,7 @@ mod tests {
         let query_type = QueryType::LatestByTs(300);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (30, 3, 300));
+        assert_eq!(tree.version(), 3);
     }
 
     #[test]
@@ -2638,6 +2646,7 @@ mod tests {
         let query_type = QueryType::LastLessThanTs(150);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (10, 1, 100));
+        assert_eq!(tree.version(), 3);
     }
 
     #[test]
@@ -2651,6 +2660,7 @@ mod tests {
         let query_type = QueryType::LastLessOrEqualTs(150);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (20, 2, 150));
+        assert_eq!(tree.version(), 3);
     }
 
     #[test]
@@ -2664,6 +2674,7 @@ mod tests {
         let query_type = QueryType::FirstGreaterThanTs(150);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (30, 3, 200));
+        assert_eq!(tree.version(), 3);
     }
 
     #[test]
@@ -2677,5 +2688,6 @@ mod tests {
         let query_type = QueryType::FirstGreaterOrEqualTs(150);
         let result = tree.get_value_by_query(&key, query_type).unwrap();
         assert_eq!(result, (20, 2, 150));
+        assert_eq!(tree.version(), 3);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,7 @@ impl<const SIZE: usize> BitSet<SIZE> {
 pub enum TrieError {
     FixedSizeKeyLengthExceeded,
     VersionIsOld,
+    RootIsNotUniquelyOwned,
 }
 
 impl Error for TrieError {}
@@ -411,6 +412,7 @@ impl fmt::Display for TrieError {
             TrieError::VersionIsOld => {
                 write!(f, "Given version is older than root's current version")
             }
+            TrieError::RootIsNotUniquelyOwned => write!(f, "Root arc is not uniquely owned"),
         }
     }
 }


### PR DESCRIPTION
## Description

`insert_unchecked` is a method used in surrealkv to load the index on startup. Currently, the load times are extremely slow because insertion at start incurs the CoW (copy-on-write) penalty unnecessarily, which is only required during transactions.

This PR makes the method mutable, so that it avoids CoW.