### PR TITLE
chore: collapse node4 to child and get rid of node 1

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -582,7 +582,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             NodeType::Node16(n) => n.num_children(),
             NodeType::Node48(n) => n.num_children(),
             NodeType::Node256(n) => n.num_children(),
-            NodeType::Twig(n) => n.num_children(),
+            NodeType::Twig(_) => 0,
         }
     }
 

--- a/src/art.rs
+++ b/src/art.rs
@@ -545,6 +545,10 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
         match &mut self.node_type {
             NodeType::Node4(n) => {
                 // Shrink Node4 to Node1 by resizing it.
+                // In an Adaptive Radix Tree (ART), when a node has only one child,
+                // it can be collapsed into its first child to save space and improve efficiency.
+                // During this process, the prefix of the current node and the prefix of the child node
+                // are combined (compressed) into a single prefix.
                 let (curr_prefix, child) = n.get_value_if_single_child();
                 let child = child.unwrap();
                 let mut child_type = child.node_type.clone();

--- a/src/art.rs
+++ b/src/art.rs
@@ -1513,24 +1513,24 @@ mod tests {
         }
     }
 
-    // // Inserting Two values into a tree and deleting them both
-    // // should result in a nil tree root
-    // // This tests the expansion of the root into a NODE4 and
-    // // successfully collapsing into a twig and then nil upon successive removals
-    // #[test]
-    // fn insert2_and_remove2_and_root_should_be_nil() {
-    //     let key1 = &VariableSizeKey::from_str("test1");
-    //     let key2 = &VariableSizeKey::from_str("test2");
+    // Inserting Two values into a tree and deleting them both
+    // should result in a nil tree root
+    // This tests the expansion of the root into a NODE4 and
+    // successfully collapsing into a twig and then nil upon successive removals
+    #[test]
+    fn insert2_and_remove2_and_root_should_be_nil() {
+        let key1 = &VariableSizeKey::from_str("test1").unwrap();
+        let key2 = &VariableSizeKey::from_str("test2").unwrap();
 
-    //     let mut tree = Tree::<VariableSizeKey, i32>::new();
-    //     tree.insert(key1, 1, 0, 0);
-    //     tree.insert(key2, 1, 0);
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
+        tree.insert(key1, 1, 0, 0).unwrap();
+        tree.insert(key2, 1, 0, 0).unwrap();
 
-    //     assert_eq!(tree.remove(key1), true);
-    //     assert_eq!(tree.remove(key2), true);
+        assert!(tree.remove(key1));
+        assert!(tree.remove(key2));
 
-    //     assert!(tree.root.is_none());
-    // }
+        assert!(tree.root.is_none());
+    }
 
     // Inserting Five values into a tree and deleting one of them
     // should result in a tree root of type NODE4
@@ -1559,26 +1559,26 @@ mod tests {
         }
     }
 
-    //     // Inserting Five values into a tree and deleting all of them
-    //     // should result in a tree root of type nil
-    //     // This tests the expansion of the root into a NODE16 and
-    //     // successfully collapsing into a NODE4, twig, then nil
-    //     #[test]
-    //     fn insert5_and_remove5_and_root_should_be_nil() {
-    //         let mut tree = Tree::<VariableSizeKey, i32>::new();
+    // Inserting Five values into a tree and deleting all of them
+    // should result in a tree root of type nil
+    // This tests the expansion of the root into a NODE16 and
+    // successfully collapsing into a NODE4, twig, then nil
+    #[test]
+    fn insert5_and_remove5_and_root_should_be_nil() {
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
-    //         for i in 0..5u32 {
-    //             let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
-    //             tree.insert(key, 1);
-    //         }
+        for i in 0..5u32 {
+            let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
+            tree.insert(key, 1, 0, 0).unwrap();
+        }
 
-    //         for i in 0..5u32 {
-    //             let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
-    //             tree.remove(key);
-    //         }
+        for i in 0..5u32 {
+            let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
+            tree.remove(key);
+        }
 
-    //         assert!(tree.root.is_none());
-    //     }
+        assert!(tree.root.is_none());
+    }
 
     // Inserting 17 values into a tree and deleting one of them should
     // result in a tree root of type NODE16
@@ -1626,26 +1626,26 @@ mod tests {
         }
     }
 
-    // // Inserting 17 values into a tree and removing them all should
-    // // result in a tree of root type nil
-    // // This tests the expansion of the root into a NODE48, and
-    // // successfully collapsing into a NODE16, NODE4, twig, and then nil
-    // #[test]
-    // fn insert17_and_remove17_and_root_should_be_nil() {
-    //     let mut tree = Tree::<VariableSizeKey, i32>::new();
+    // Inserting 17 values into a tree and removing them all should
+    // result in a tree of root type nil
+    // This tests the expansion of the root into a NODE48, and
+    // successfully collapsing into a NODE16, NODE4, twig, and then nil
+    #[test]
+    fn insert17_and_remove17_and_root_should_be_nil() {
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
-    //     for i in 0..17u32 {
-    //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
-    //         tree.insert(&key, 1);
-    //     }
+        for i in 0..17u32 {
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
+            tree.insert(&key, 1, 0, 0).unwrap();
+        }
 
-    //     for i in 0..17u32 {
-    //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
-    //         tree.remove(&key);
-    //     }
+        for i in 0..17u32 {
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
+            tree.remove(&key);
+        }
 
-    //     assert!(tree.root.is_none());
-    // }
+        assert!(tree.root.is_none());
+    }
 
     // Inserting 49 values into a tree and removing one of them should
     // result in a tree root of type NODE48
@@ -1693,26 +1693,26 @@ mod tests {
         }
     }
 
-    //     // // Inserting 49 values into a tree and removing all of them should
-    //     // // result in a nil tree root
-    //     // // This tests the expansion of the root into a NODE256, and
-    //     // // successfully collapsing into a Node48, Node16, Node4, twig, and finally nil
-    //     // #[test]
-    //     // fn insert49_and_remove49_and_root_should_be_nil() {
-    //     //     let mut tree = Tree::<VariableSizeKey, i32>::new();
+    // Inserting 49 values into a tree and removing all of them should
+    // result in a nil tree root
+    // This tests the expansion of the root into a NODE256, and
+    // successfully collapsing into a Node48, Node16, Node4, twig, and finally nil
+    #[test]
+    fn insert49_and_remove49_and_root_should_be_nil() {
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
 
-    //     //     for i in 0..49u32 {
-    //     //         let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
-    //     //         tree.insert(key, 1);
-    //     //     }
+        for i in 0..49u32 {
+            let key = &VariableSizeKey::from_slice(&i.to_be_bytes());
+            tree.insert(key, 1, 0, 0).unwrap();
+        }
 
-    //     //     for i in 0..49u32 {
-    //     //         let key = VariableSizeKey::from_slice(&i.to_be_bytes());
-    //     //         assert_eq!(tree.remove(&key), true);
-    //     //     }
+        for i in 0..49u32 {
+            let key = VariableSizeKey::from_slice(&i.to_be_bytes());
+            assert!(tree.remove(&key));
+        }
 
-    //     //     assert!(tree.root.is_none());
-    //     // }
+        assert!(tree.root.is_none());
+    }
 
     #[derive(Debug, Clone, PartialEq)]
     struct Kvt {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1032,7 +1032,6 @@ mod tests {
             (b"kiwi\0".to_vec(), &10, &10, &0),
         ];
 
-        println!("{} {:?}", results.len(), results);
         assert_eq!(results, expected);
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -61,12 +61,7 @@ impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
         }
     }
 
-    #[inline(always)]
-    pub fn num_children(&self) -> usize {
-        self.values.len()
-    }
-
-    pub fn version(&self) -> u64 {
+    pub(crate) fn version(&self) -> u64 {
         self.values
             .iter()
             .map(|value| value.version)
@@ -284,12 +279,12 @@ impl<P: KeyTrait, N: Version, const WIDTH: usize> FlatNode<P, N, WIDTH> {
         new_node
     }
 
-    pub fn get_value_if_single_child(&self) -> (&P, Option<Arc<N>>) {
+    pub(crate) fn get_value_if_single_child(&self) -> (&P, Option<Arc<N>>) {
         assert_eq!(self.num_children, 1);
         (&self.prefix, self.children[0].clone())
     }
 
-    pub fn grow(&self) -> Node48<P, N> {
+    pub(crate) fn grow(&self) -> Node48<P, N> {
         let mut n48 = Node48::new(self.prefix.clone());
         for i in 0..self.num_children as usize {
             if let Some(child) = self.children[i].as_ref() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -61,7 +61,12 @@ impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
         }
     }
 
-    pub(crate) fn version(&self) -> u64 {
+    #[inline(always)]
+    pub fn num_children(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn version(&self) -> u64 {
         self.values
             .iter()
             .map(|value| value.version)
@@ -279,7 +284,12 @@ impl<P: KeyTrait, N: Version, const WIDTH: usize> FlatNode<P, N, WIDTH> {
         new_node
     }
 
-    pub(crate) fn grow(&self) -> Node48<P, N> {
+    pub fn get_value_if_single_child(&self) -> (&P, Option<Arc<N>>) {
+        assert_eq!(self.num_children, 1);
+        (&self.prefix, self.children[0].clone())
+    }
+
+    pub fn grow(&self) -> Node48<P, N> {
         let mut n48 = Node48::new(self.prefix.clone());
         for i in 0..self.num_children as usize {
             if let Some(child) = self.children[i].as_ref() {


### PR DESCRIPTION
## Description

As per the ART paper, when a Node4 has a single child should have its child collapsed into it. Currently this is not implemented, and rather a Node4 is collapsed into a Node1 which doesn't really help in compression. This PR implements delete as per the paper.

Some benchmark results

```
# main

seq_delete/vart         time:   [1.3538 µs 1.3743 µs 1.3913 µs]
                        thrpt:  [718.76 Kelem/s 727.64 Kelem/s 738.67 Kelem/s]

rand_delete/vart        time:   [2.4015 µs 2.4515 µs 2.5083 µs]
                        thrpt:  [398.68 Kelem/s 407.92 Kelem/s 416.40 Kelem/s]
```

```
# chore/collapse-node4-to-child

seq_delete/vart         time:   [1.1587 µs 1.1767 µs 1.1914 µs]
                        thrpt:  [839.36 Kelem/s 849.85 Kelem/s 863.07 Kelem/s]


rand_delete/vart        time:   [1.8899 µs 1.9467 µs 2.0162 µs]
                        thrpt:  [495.99 Kelem/s 513.70 Kelem/s 529.12 Kelem/s]
```