### PR TITLE
Add insert_or_replace methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vart"
 publish = true
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/node.rs
+++ b/src/node.rs
@@ -127,6 +127,13 @@ impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
         self.version = self.version(); // Update LeafNode's version
     }
 
+    pub(crate) fn replace_if_newer_mut(&mut self, value: V, version: u64, ts: u64) {
+        if version > self.version {
+            self.values.clear();
+            self.insert_mut(value, version, ts);
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = &Arc<LeafValue<V>>> {
         self.values.iter()
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -25,7 +25,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
         // Insert the key-value pair into the root node using a recursive function
         match &self.root {
             Some(root) => {
-                let new_node = Node::insert_recurse(root, key, value, self.ts, ts, 0);
+                let new_node = Node::insert_recurse(root, key, value, self.ts, ts, 0, false);
                 // Update the root node with the new node after insertion
                 self.root = Some(new_node);
             }


### PR DESCRIPTION
Add `Tree::insert_or_replace` and `Tree::insert_or_replace_unchecked` methods. They will be used in SurrealKV configured to run without versions. The idea is that since we don't need to keep previous versions of values in the index in memory, then for the existing keys we can simply replace the previous value with the new one by using `Tree::insert_or_replace`. `Tree::insert_or_replace_unchecked` is used for loading the index, so we only keep the value with the largest version, i.e. the most recent one.

A few notes:
1. The implementation is simple but not the most optimised one. In the future we might want to add a special method for `Twig` nodes instead of clearing all existing values and then doing `insert_mut()`.
2. This implementation is not sufficient for handling the online compaction with versions enabled, but let's cross that bridge when we get there. Currently the focus is to handle the case without versions.