### PR TITLE
Chore/add twig node types

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -125,9 +125,20 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
     /// Returns a new `Node` instance with a Twig node containing the provided key, value, and version.
     ///
     #[inline]
-    pub(crate) fn new_twig(prefix: P, key: P, value: V, version: u64, ts: u64) -> Node<P, V> {
+    pub(crate) fn new_twig(
+        prefix: P,
+        key: P,
+        value: V,
+        version: u64,
+        ts: u64,
+        is_single: bool,
+    ) -> Node<P, V> {
         // Create a new TwigNode instance using the provided prefix and key.
-        let mut twig = TwigNode::new(prefix, key);
+        let mut twig = if is_single {
+            TwigNode::new_single(prefix, key)
+        } else {
+            TwigNode::new(prefix, key)
+        };
 
         // Insert the provided value into the TwigNode along with the version.
         twig.insert_mut(value, version, ts);
@@ -714,7 +725,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             if is_prefix_match && twig.prefix.len() == key_prefix.len() {
                 let new_twig = if replace {
                     // Create a replacement Twig node with the new value only.
-                    let mut new_twig = TwigNode::new(twig.prefix.clone(), twig.key.clone());
+                    let mut new_twig = TwigNode::new_single(twig.prefix.clone(), twig.key.clone());
                     new_twig.insert_mut(value, commit_version, ts);
                     new_twig
                 } else {
@@ -740,6 +751,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
                 value,
                 commit_version,
                 ts,
+                replace,
             );
             n4 = n4.add_child(k1, old_node).add_child(k2, new_twig);
 
@@ -770,6 +782,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             value,
             commit_version,
             ts,
+            replace,
         );
         let new_node = cur_node.add_child(k, new_twig);
 
@@ -825,6 +838,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
                 value,
                 commit_version,
                 ts,
+                replace,
             );
             cur_node.add_child_mut(k1, old_node);
             cur_node.add_child_mut(k2, new_twig);
@@ -856,6 +870,7 @@ impl<P: KeyTrait, V: Clone> Node<P, V> {
             value,
             commit_version,
             ts,
+            replace,
         );
         cur_node.add_child_mut(k, new_twig);
     }
@@ -1054,6 +1069,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
                     value,
                     commit_version,
                     ts,
+                    replace,
                 ))
             }
             Some(root) => {
@@ -1103,6 +1119,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
                 value,
                 commit_version,
                 ts,
+                replace,
             )));
         }
         self.size += 1;

--- a/src/node.rs
+++ b/src/node.rs
@@ -85,6 +85,17 @@ impl<V: Clone> Values<V> {
             }
         }
     }
+
+    pub(crate) fn clear(&mut self) {
+        match self {
+            Values::Single(_) => {
+                *self = Values::Single(None);
+            }
+            Values::Multiple(values) => {
+                values.clear();
+            }
+        }
+    }
 }
 
 impl<'a, V: Clone> Iterator for ValuesIter<'a, V> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -68,24 +68,6 @@ impl<V: Clone> Values<V> {
         }
     }
 
-    pub(crate) fn set_single(&mut self, value: Arc<LeafValue<V>>) {
-        *self = Values::Single(Some(value));
-    }
-
-    pub(crate) fn add_multiple(&mut self, value: Arc<LeafValue<V>>) {
-        match self {
-            Values::Single(Some(existing_value)) => {
-                *self = Values::Multiple(vec![existing_value.clone(), value]);
-            }
-            Values::Single(None) => {
-                *self = Values::Multiple(vec![value]);
-            }
-            Values::Multiple(values) => {
-                values.push(value);
-            }
-        }
-    }
-
     pub(crate) fn clear(&mut self) {
         match self {
             Values::Single(_) => {
@@ -155,7 +137,7 @@ impl<K: KeyTrait, V: Clone> TwigNode<K, V> {
         }
     }
 
-    pub(crate) fn new_unversioned(prefix: K, key: K) -> Self {
+    pub(crate) fn new_single(prefix: K, key: K) -> Self {
         TwigNode {
             prefix,
             key,

--- a/src/node.rs
+++ b/src/node.rs
@@ -60,6 +60,7 @@ impl<V: Clone> Values<V> {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn len(&self) -> usize {
         match self {
             Values::Single(Some(_)) => 1,
@@ -1278,8 +1279,6 @@ mod tests {
 
         node.insert_mut(42, 123, 0);
         assert_eq!(node.values.len(), 1);
-        // assert_eq!(node.values[0].value, 42);
-        // assert_eq!(node.values[0].version, 123);
 
         let mut iter = node.values.iter();
         if let Some(first_value) = iter.next() {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -36,6 +36,7 @@ impl<P: KeyTrait, V: Clone> Snapshot<P, V> {
                     value,
                     self.version,
                     ts,
+                    false,
                 )))
             }
         };


### PR DESCRIPTION
## Description

Categorises values inside TwigNode as Single/Multiple to avoid allocating a vector for a single value