### PR TITLE
Use Btree for version history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,9 @@ criterion = "0.5.1"
 divan = "0.1.14"
 
 [features]
-default = ["vec_store"]
+default = ["btree_store"]
 vec_store = []
-
-[[bench]]
-name = "vart_bench"
-path = "benches/vart_bench.rs"
-harness = false
+btree_store = []
 
 [[bench]]
 name = "allocs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ rand = "0.8.5"
 criterion = "0.5.1"
 divan = "0.1.14"
 
+[features]
+default = ["vec_store"]
+vec_store = []
+
 [[bench]]
 name = "vart_bench"
 path = "benches/vart_bench.rs"

--- a/src/art.rs
+++ b/src/art.rs
@@ -1747,10 +1747,11 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
 mod tests {
     use super::Tree;
     use crate::art::QueryType;
-    use crate::{FixedSizeKey, VariableSizeKey};
+    use crate::{FixedSizeKey, KeyTrait, VariableSizeKey};
     use rand::{seq::SliceRandom, thread_rng, Rng};
     use std::ops::RangeFull;
     use std::str::FromStr;
+    use std::time::Instant;
 
     use rand::distributions::Alphanumeric;
     use std::fs::File;
@@ -3675,4 +3676,109 @@ mod tests {
             assert!(tree.remove(&key1));
         }
     }
+
+    #[test]
+    fn test_insert_multiple_version_keys() {
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
+
+        let start = std::time::Instant::now();
+
+        let num_keys = 100; // Number of keys
+        let versions_per_key = 10_000; // Number of versions per key
+
+        // Insert 100,00 versions for each of the 100 keys
+        for key_index in 0..num_keys {
+            let key = VariableSizeKey::from_str(&format!("key_{}", key_index)).unwrap();
+
+            for version_index in 0..versions_per_key {
+                let value = key_index * versions_per_key + version_index; // Value for versioning
+                tree.insert_unchecked(&key, value, 0, 0).unwrap();
+            }
+        }
+
+        println!(
+            "Insertion time for 1M key-version pairs: {:?}",
+            start.elapsed()
+        );
+    }
+
+    fn run_query_benchmark<P: KeyTrait + Clone, V: Clone>(
+        tree: &Tree<P, V>,
+        key: &P,
+        query_type: QueryType,
+        iterations: u32,
+    ) -> std::time::Duration {
+        let start = Instant::now();
+        for _ in 0..iterations {
+            let _ = tree.get_value_by_query(key, query_type);
+        }
+        start.elapsed()
+    }
+
+    #[test]
+    fn benchmark_timestamp_queries() {
+        let mut tree = Tree::<VariableSizeKey, i32>::new();
+
+        // Test parameters
+        let num_keys = 100;
+        let versions_per_key = 10_000;
+        let query_iterations = 1;
+
+        println!("Setting up test data...");
+        let setup_start = Instant::now();
+
+        // Insert test data with incrementing timestamps
+        for key_idx in 0..num_keys {
+            let key = VariableSizeKey::from_str(&format!("key_{}", key_idx)).unwrap();
+            for version in 0..versions_per_key {
+                let value = key_idx * versions_per_key + version;
+                let ts = version as u64; // Using version as timestamp for predictable ordering
+                tree.insert_unchecked(&key, value, version as u64, ts)
+                    .unwrap();
+            }
+        }
+
+        println!("Setup completed in {:?}", setup_start.elapsed());
+
+        // Select a key in the middle for testing
+        let test_key = VariableSizeKey::from_str("key_50").unwrap();
+        let mid_ts = (versions_per_key / 2) as u64;
+
+        // Test cases
+        let test_cases = vec![
+            ("LatestByVersion", QueryType::LatestByVersion(mid_ts)),
+            ("LatestByTs", QueryType::LatestByTs(mid_ts)),
+            ("LastLessThanTs", QueryType::LastLessThanTs(mid_ts)),
+            ("LastLessOrEqualTs", QueryType::LastLessOrEqualTs(mid_ts)),
+            ("FirstGreaterThanTs", QueryType::FirstGreaterThanTs(mid_ts)),
+            (
+                "FirstGreaterOrEqualTs",
+                QueryType::FirstGreaterOrEqualTs(mid_ts),
+            ),
+        ];
+
+        println!("\nRunning performance tests...");
+        println!(
+            "Each query type will be executed {} times",
+            query_iterations
+        );
+        println!(
+            "Tree contains {} keys with {} versions each",
+            num_keys, versions_per_key
+        );
+        println!("\nResults:");
+        println!(
+            "{:<25} {:<15} {:<10}",
+            "Query Type", "Total Time", "Avg Time"
+        );
+        println!("{}", "-".repeat(50));
+
+        for (name, query_type) in test_cases {
+            let duration = run_query_benchmark(&tree, &test_key, query_type, query_iterations);
+            let avg_duration = duration.div_f64(query_iterations as f64);
+
+            println!("{:<25} {:?} {:?}", name, duration, avg_duration);
+        }
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod art;
 pub mod iter;
 pub mod node;
+pub mod version;
 
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::error::Error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -154,21 +154,13 @@ impl<K: KeyTrait + Clone, V: Clone> TwigNode<K, V> {
 
     #[inline]
     pub(crate) fn get_leaf_by_ts(&self, ts: u64) -> Option<&Arc<LeafValue<V>>> {
-        // self.values
-        //     .iter()
-        //     .filter(|value| value.ts <= ts)
-        //     .max_by_key(|value| value.ts)
-
         self.values
-        .iter()
-        .filter(|value| {
-            let should_include = value.ts <= ts;
-            if should_include {
-                println!("Version: {:?}, Key: {:?}, TS: {}", value.version, self.key, value.ts);
-            }
-            should_include
-        })
-        .max_by_key(|value| value.ts)
+            .iter()
+            .filter(|value| value.ts <= ts)
+            .max_by(|a, b| {
+                a.ts.cmp(&b.ts)
+                    .then_with(|| Arc::as_ptr(a).cmp(&Arc::as_ptr(b)))
+            })
     }
 
     #[inline]

--- a/src/node.rs
+++ b/src/node.rs
@@ -158,8 +158,7 @@ impl<K: KeyTrait + Clone, V: Clone> TwigNode<K, V> {
             .iter()
             .filter(|value| value.ts <= ts)
             .max_by(|a, b| {
-                a.ts.cmp(&b.ts)
-                    .then_with(|| Arc::as_ptr(a).cmp(&Arc::as_ptr(b)))
+                a.ts.cmp(&b.ts).then_with(|| std::cmp::Ordering::Greater) // Always prefer the second entry
             })
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,479 @@
+use std::sync::Arc;
+
+use crate::node::LeafValue;
+
+const B: usize = 6; // B-tree degree (max children = 2B)
+
+#[derive(Clone)]
+pub(crate) struct BTree<V: Clone> {
+    root: Option<Arc<BNode<V>>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct BNode<V: Clone> {
+    entries: Vec<Arc<LeafValue<V>>>,
+    children: Vec<Arc<BNode<V>>>,
+    is_leaf: bool,
+}
+
+impl<V: Clone> BNode<V> {
+    fn new(is_leaf: bool) -> Self {
+        BNode {
+            entries: Vec::with_capacity(2 * B - 1),
+            children: if is_leaf {
+                Vec::new()
+            } else {
+                Vec::with_capacity(2 * B)
+            },
+            is_leaf,
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.entries.len() >= 2 * B - 1
+    }
+}
+
+impl<V: Clone> BTree<V> {
+    pub fn new() -> Self {
+        BTree { root: None }
+    }
+
+    pub fn insert(&mut self, value: V, version: u64, ts: u64) {
+        let leaf_value = Arc::new(LeafValue::new(value, version, ts));
+        match self.root.take() {
+            None => {
+                let mut root = BNode::new(true);
+                root.entries.push(leaf_value);
+                self.root = Some(Arc::new(root));
+            }
+            Some(root) => {
+                if root.is_full() {
+                    let mut new_root = BNode::new(false);
+                    new_root.children.push(root);
+                    self.split_child(&mut new_root, 0);
+                    self.insert_non_full(&mut new_root, leaf_value);
+                    self.root = Some(Arc::new(new_root));
+                } else {
+                    let mut root = (*root).clone();
+                    self.insert_non_full(&mut root, leaf_value);
+                    self.root = Some(Arc::new(root));
+                }
+            }
+        }
+    }
+
+    fn split_child(&self, parent: &mut BNode<V>, index: usize) {
+        let child = Arc::clone(&parent.children[index]);
+        let mut new_child = BNode::new(child.is_leaf);
+
+        let mid = (child.entries.len() - 1) / 2;
+        new_child.entries = child.entries[mid + 1..].to_vec();
+        let middle_entry = child.entries[mid].clone();
+        let mut child = (*child).clone();
+        child.entries.truncate(mid);
+
+        if !child.is_leaf {
+            let mid_child = (child.children.len() + 1) / 2;
+            new_child.children = child.children[mid_child..].to_vec();
+            child.children.truncate(mid_child);
+        }
+
+        parent.entries.insert(index, middle_entry);
+        parent.children[index] = Arc::new(child);
+        parent.children.insert(index + 1, Arc::new(new_child));
+    }
+
+    fn insert_non_full(&self, node: &mut BNode<V>, leaf_value: Arc<LeafValue<V>>) {
+        let mut i = node.entries.len();
+
+        if node.is_leaf {
+            while i > 0
+                && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
+            {
+                i -= 1;
+            }
+            node.entries.insert(i, leaf_value);
+        } else {
+            while i > 0
+                && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
+            {
+                i -= 1;
+            }
+
+            let child = Arc::clone(&node.children[i]);
+            if child.is_full() {
+                self.split_child(node, i);
+                if self.should_go_right(&node.entries[i], leaf_value.version, leaf_value.ts) {
+                    i += 1;
+                }
+            }
+
+            let mut child = (*node.children[i]).clone();
+            self.insert_non_full(&mut child, leaf_value);
+            node.children[i] = Arc::new(child);
+        }
+    }
+
+    fn should_go_right(&self, entry: &LeafValue<V>, version: u64, ts: u64) -> bool {
+        if version != entry.version {
+            version > entry.version
+        } else {
+            ts > entry.ts
+        }
+    }
+
+    pub fn search(&self, version: u64, ts: u64) -> Option<&Arc<LeafValue<V>>> {
+        let root = self.root.as_ref()?;
+        self.search_node(root, version, ts)
+    }
+
+    fn search_node<'a>(
+        &'a self,
+        node: &'a BNode<V>,
+        version: u64,
+        ts: u64,
+    ) -> Option<&'a Arc<LeafValue<V>>> {
+        let mut i = 0;
+
+        while i < node.entries.len() && self.should_go_right(&node.entries[i], version, ts) {
+            i += 1;
+        }
+
+        if i < node.entries.len() && version == node.entries[i].version && ts == node.entries[i].ts
+        {
+            Some(&node.entries[i])
+        } else if node.is_leaf {
+            None
+        } else {
+            self.search_node(&node.children[i], version, ts)
+        }
+    }
+
+    pub fn last_less_or_equal_ts(&self, ts: u64) -> Option<&Arc<LeafValue<V>>> {
+        let root = self.root.as_ref()?;
+        self.last_less_or_equal_ts_node(root, ts, None)
+    }
+
+    fn last_less_or_equal_ts_node<'a>(
+        &'a self,
+        node: &'a BNode<V>,
+        ts: u64,
+        mut best_so_far: Option<&'a Arc<LeafValue<V>>>,
+    ) -> Option<&'a Arc<LeafValue<V>>> {
+        for entry in &node.entries {
+            if entry.ts <= ts {
+                match best_so_far {
+                    None => best_so_far = Some(entry),
+                    Some(best) if entry.ts > best.ts => best_so_far = Some(entry),
+                    _ => {}
+                }
+            }
+        }
+
+        if !node.is_leaf {
+            for child in &node.children {
+                best_so_far = self.last_less_or_equal_ts_node(child, ts, best_so_far);
+            }
+        }
+
+        best_so_far
+    }
+
+    // Add an iterator that yields Arc<LeafValue<V>> references
+    pub fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_> {
+        match &self.root {
+            None => Box::new(std::iter::empty()),
+            Some(root) => Box::new(BNodeIterator::new(root)),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.root = None;
+    }
+}
+
+// Iterator for BNode
+struct BNodeIterator<'a, V: Clone> {
+    stack: Vec<(&'a BNode<V>, usize)>,
+    reverse_stack: Vec<(&'a BNode<V>, usize)>,
+}
+
+impl<'a, V: Clone> BNodeIterator<'a, V> {
+    fn new(root: &'a Arc<BNode<V>>) -> Self {
+        let mut iter = BNodeIterator {
+            stack: Vec::new(),
+            reverse_stack: Vec::new(),
+        };
+        iter.push_left(root);
+        iter.push_right(root);
+        iter
+    }
+
+    fn push_left(&mut self, node: &'a Arc<BNode<V>>) {
+        let mut current = node;
+        while let Some(first_child) = current.children.first() {
+            self.stack.push((current, 0));
+            current = first_child;
+        }
+        self.stack.push((current, 0));
+    }
+
+    fn push_right(&mut self, node: &'a Arc<BNode<V>>) {
+        let mut current = node;
+        while let Some(last_child) = current.children.last() {
+            self.reverse_stack.push((current, current.entries.len()));
+            current = last_child;
+        }
+        self.reverse_stack.push((current, current.entries.len()));
+    }
+}
+
+impl<'a, V: Clone> Iterator for BNodeIterator<'a, V> {
+    type Item = &'a Arc<LeafValue<V>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((node, index)) = self.stack.pop() {
+            if index < node.entries.len() {
+                if index + 1 < node.entries.len() {
+                    self.stack.push((node, index + 1));
+                } else if let Some(next_child) = node.children.get(index + 1) {
+                    self.push_left(next_child);
+                }
+                return Some(&node.entries[index]);
+            }
+        }
+        None
+    }
+}
+
+impl<'a, V: Clone> DoubleEndedIterator for BNodeIterator<'a, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        while let Some((node, index)) = self.reverse_stack.pop() {
+            if index > 0 {
+                if index - 1 > 0 {
+                    self.reverse_stack.push((node, index - 1));
+                } else if let Some(prev_child) = node.children.get(index - 1) {
+                    self.push_right(prev_child);
+                }
+                return Some(&node.entries[index - 1]);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_btree_basic_insert() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(42, 1, 100);
+
+        let result = tree.search(1, 100);
+        assert_eq!(result.map(|leaf| &leaf.value), Some(&42));
+    }
+
+    #[test]
+    fn test_btree_multiple_versions() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(10, 1, 100);
+        tree.insert(20, 2, 200);
+        tree.insert(30, 3, 300);
+
+        assert_eq!(tree.search(1, 100).map(|leaf| &leaf.value), Some(&10));
+        assert_eq!(tree.search(2, 200).map(|leaf| &leaf.value), Some(&20));
+        assert_eq!(tree.search(3, 300).map(|leaf| &leaf.value), Some(&30));
+    }
+
+    #[test]
+    fn test_btree_same_version_different_ts() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(10, 1, 200);
+        tree.insert(20, 1, 100);
+
+        let result = tree.last_less_or_equal_ts(150);
+        assert_eq!(
+            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((20, 1, 100))
+        );
+
+        let result = tree.last_less_or_equal_ts(300);
+        assert_eq!(
+            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((10, 1, 200))
+        );
+    }
+
+    #[test]
+    fn test_btree_full_node_split() {
+        let mut tree = BTree::<i32>::new();
+        // Insert 2*B entries to force splits
+        for i in 0..2 * B {
+            tree.insert(i as i32, i as u64, i as u64);
+        }
+
+        // Verify all entries are still accessible
+        for i in 0..2 * B {
+            assert_eq!(
+                tree.search(i as u64, i as u64).map(|leaf| leaf.value),
+                Some(i as i32)
+            );
+        }
+    }
+
+    #[test]
+    fn test_btree_timestamp_queries() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(10, 1, 100);
+        tree.insert(20, 1, 200);
+        tree.insert(30, 1, 300);
+        tree.insert(40, 1, 400);
+
+        // Test last_less_or_equal_ts
+        assert!(tree.last_less_or_equal_ts(50).is_none());
+        assert_eq!(
+            tree.last_less_or_equal_ts(150)
+                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((10, 1, 100))
+        );
+        assert_eq!(
+            tree.last_less_or_equal_ts(250)
+                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((20, 1, 200))
+        );
+        assert_eq!(
+            tree.last_less_or_equal_ts(350)
+                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((30, 1, 300))
+        );
+        assert_eq!(
+            tree.last_less_or_equal_ts(500)
+                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((40, 1, 400))
+        );
+    }
+
+    #[test]
+    fn test_btree_copy_on_write() {
+        let mut tree1 = BTree::<i32>::new();
+        tree1.insert(10, 1, 100);
+
+        let tree2 = tree1.clone();
+        tree1.insert(20, 2, 200);
+
+        // Original version should be preserved in tree2
+        assert_eq!(tree2.search(1, 100).map(|leaf| leaf.value), Some(10));
+        assert!(tree2.search(2, 200).is_none());
+
+        // New version should be available in tree1
+        assert_eq!(tree1.search(1, 100).map(|leaf| leaf.value), Some(10));
+        assert_eq!(tree1.search(2, 200).map(|leaf| leaf.value), Some(20));
+    }
+
+    #[test]
+    fn test_btree_decreasing_timestamps() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(10, 1, 200);
+        tree.insert(20, 2, 100);
+
+        let result = tree.last_less_or_equal_ts(100);
+        assert_eq!(
+            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((20, 2, 100))
+        );
+
+        let result = tree.last_less_or_equal_ts(200);
+        assert_eq!(
+            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((10, 1, 200))
+        );
+    }
+
+    #[test]
+    fn test_btree_large_dataset() {
+        let mut tree = BTree::<i32>::new();
+        for i in 0..1000 {
+            tree.insert(i, i as u64, (i * 2) as u64);
+        }
+
+        // Test random access
+        assert_eq!(tree.search(500, 1000).map(|leaf| leaf.value), Some(500));
+
+        // Test timestamp queries
+        assert_eq!(
+            tree.last_less_or_equal_ts(1500)
+                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
+            Some((750, 750, 1500))
+        );
+    }
+
+    #[test]
+    fn test_btree_empty() {
+        let tree: BTree<i32> = BTree::new();
+        assert!(tree.search(1, 100).is_none());
+        assert!(tree.last_less_or_equal_ts(100).is_none());
+    }
+
+    #[test]
+    fn test_btree_overwrite_version_ts() {
+        let mut tree = BTree::<i32>::new();
+        tree.insert(10, 1, 100);
+        tree.insert(20, 1, 100); // Same version and timestamp
+
+        assert_eq!(tree.search(1, 100).map(|leaf| leaf.value), Some(20)); // Should have latest value
+    }
+
+    #[test]
+    fn test_btree_concurrent_versions() {
+        use std::thread;
+
+        let tree = Arc::new(std::sync::Mutex::new(BTree::<i32>::new()));
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let tree_clone = Arc::clone(&tree);
+            let handle = thread::spawn(move || {
+                let mut tree = tree_clone.lock().unwrap();
+                tree.insert(i, i as u64, (i * 10) as u64);
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let final_tree = tree.lock().unwrap();
+        for i in 0..10 {
+            assert!(final_tree.search(i as u64, (i * 10) as u64).is_some());
+        }
+    }
+
+    #[test]
+    fn test_btree_insert_at_same_version() {
+        let mut tree = BTree::<i32>::new();
+
+        let ts = 100;
+        tree.insert(10, 1, ts);
+        tree.insert(20, 1, ts);
+
+        let val = tree
+        .iter()
+        .filter(|value| {
+            let should_include = value.ts <= ts;
+            if should_include {
+                println!("Version: {:?}, TS: {}", value.version, value.ts);
+            }
+            should_include
+        })
+        .max_by_key(|value| value.ts).unwrap();
+        println!("Max value: {:?}", val.value);
+
+
+        assert_eq!(tree.search(1, ts).map(|leaf| &leaf.value), Some(&20));
+    }
+
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -32,11 +32,6 @@ impl<V: Clone> BNode<V> {
     fn is_full(&self) -> bool {
         self.entries.len() >= 2 * B - 1
     }
-
-    // New method to get mutable access to entries and children
-    fn get_mut_parts(&mut self) -> (&mut Vec<Arc<LeafValue<V>>>, &mut Vec<Arc<BNode<V>>>) {
-        (&mut self.entries, &mut self.children)
-    }
 }
 
 impl<V: Clone> BTree<V> {
@@ -68,7 +63,7 @@ impl<V: Clone> BTree<V> {
     }
 
     fn split_child(&self, parent: &mut BNode<V>, index: usize) {
-        let (parent_entries, parent_children) = parent.get_mut_parts();
+        let (parent_entries, parent_children) = (&mut parent.entries, &mut parent.children);
         let child = Arc::make_mut(&mut parent_children[index]);
         let mut new_child = BNode::new(child.is_leaf);
 
@@ -123,6 +118,7 @@ impl<V: Clone> BTree<V> {
         self.insert_non_full(child, leaf_value);
     }
 
+    #[allow(unused)]
     pub fn search(&self, version: u64, ts: u64) -> Option<&Arc<LeafValue<V>>> {
         let root = self.root.as_ref()?;
         self.search_node(root, version, ts)

--- a/src/version.rs
+++ b/src/version.rs
@@ -248,7 +248,6 @@ pub(crate) trait VersionStore<V: Clone> {
     fn insert(&mut self, value: V, version: u64, ts: u64);
     fn clear(&mut self);
     fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_>;
-    fn get_max_version(&self) -> Option<u64>;
 }
 
 // Implement for Vec
@@ -304,20 +303,16 @@ impl<V: Clone> VersionStore<V> for VecStore<V> {
     fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_> {
         Box::new(self.values.iter())
     }
-
-    fn get_max_version(&self) -> Option<u64> {
-        self.values.iter().map(|value| value.version).max()
-    }
 }
 
 // Implement for BTree
-#[cfg(not(feature = "vec_store"))]
+#[cfg(feature = "btree_store")]
 #[derive(Clone)]
 pub(crate) struct BTreeStore<V: Clone> {
     values: BTree<V>,
 }
 
-#[cfg(not(feature = "vec_store"))]
+#[cfg(feature = "btree_store")]
 impl<V: Clone> VersionStore<V> for BTreeStore<V> {
     fn new() -> Self {
         Self {
@@ -335,10 +330,6 @@ impl<V: Clone> VersionStore<V> for BTreeStore<V> {
 
     fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_> {
         Box::new(self.values.iter())
-    }
-
-    fn get_max_version(&self) -> Option<u64> {
-        self.values.iter().map(|value| value.version).max()
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -93,14 +93,7 @@ impl<V: Clone> BTree<V> {
             {
                 i -= 1;
             }
-            // Check for duplicate version and replace if the new one has the same or later timestamp
-            if i > 0 && node.entries[i - 1].version == leaf_value.version {
-                if node.entries[i - 1].ts <= leaf_value.ts {
-                    node.entries[i - 1] = leaf_value;
-                }
-            } else {
-                node.entries.insert(i, leaf_value);
-            }
+            node.entries.insert(i, leaf_value);
         } else {
             while i > 0
                 && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
@@ -121,37 +114,6 @@ impl<V: Clone> BTree<V> {
             node.children[i] = Arc::new(child);
         }
     }
-
-    // fn insert_non_full(&self, node: &mut BNode<V>, leaf_value: Arc<LeafValue<V>>) {
-    //     let mut i = node.entries.len();
-
-    //     if node.is_leaf {
-    //         while i > 0
-    //             && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
-    //         {
-    //             i -= 1;
-    //         }
-    //         node.entries.insert(i, leaf_value);
-    //     } else {
-    //         while i > 0
-    //             && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
-    //         {
-    //             i -= 1;
-    //         }
-
-    //         let child = Arc::clone(&node.children[i]);
-    //         if child.is_full() {
-    //             self.split_child(node, i);
-    //             if self.should_go_right(&node.entries[i], leaf_value.version, leaf_value.ts) {
-    //                 i += 1;
-    //             }
-    //         }
-
-    //         let mut child = (*node.children[i]).clone();
-    //         self.insert_non_full(&mut child, leaf_value);
-    //         node.children[i] = Arc::new(child);
-    //     }
-    // }
 
     fn should_go_right(&self, entry: &LeafValue<V>, version: u64, ts: u64) -> bool {
         if version != entry.version {
@@ -502,8 +464,7 @@ mod tests {
             .iter()
             .filter(|value| value.ts <= ts)
             .max_by(|a, b| {
-                a.ts.cmp(&b.ts)
-                    .then_with(|| Arc::as_ptr(a).cmp(&Arc::as_ptr(b)))
+                a.ts.cmp(&b.ts).then_with(|| std::cmp::Ordering::Greater) // Always prefer the second entry
             })
             .unwrap();
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,8 +1,7 @@
+use crate::node::LeafValue;
 use std::sync::Arc;
 
-use crate::node::LeafValue;
-
-const B: usize = 6; // B-tree degree (max children = 2B)
+const B: usize = 8;
 
 #[derive(Clone)]
 pub(crate) struct BTree<V: Clone> {
@@ -29,8 +28,14 @@ impl<V: Clone> BNode<V> {
         }
     }
 
+    #[inline]
     fn is_full(&self) -> bool {
         self.entries.len() >= 2 * B - 1
+    }
+
+    // New method to get mutable access to entries and children
+    fn get_mut_parts(&mut self) -> (&mut Vec<Arc<LeafValue<V>>>, &mut Vec<Arc<BNode<V>>>) {
+        (&mut self.entries, &mut self.children)
     }
 }
 
@@ -39,88 +44,83 @@ impl<V: Clone> BTree<V> {
         BTree { root: None }
     }
 
+    #[inline]
     pub fn insert(&mut self, value: V, version: u64, ts: u64) {
         let leaf_value = Arc::new(LeafValue::new(value, version, ts));
-        match self.root.take() {
-            None => {
-                let mut root = BNode::new(true);
-                root.entries.push(leaf_value);
+
+        if let Some(root) = self.root.take() {
+            if root.is_full() {
+                let mut new_root = BNode::new(false);
+                new_root.children.push(root);
+                self.split_child(&mut new_root, 0);
+                self.insert_non_full(&mut new_root, leaf_value);
+                self.root = Some(Arc::new(new_root));
+            } else {
+                let mut root = (*root).clone();
+                self.insert_non_full(&mut root, leaf_value);
                 self.root = Some(Arc::new(root));
             }
-            Some(root) => {
-                if root.is_full() {
-                    let mut new_root = BNode::new(false);
-                    new_root.children.push(root);
-                    self.split_child(&mut new_root, 0);
-                    self.insert_non_full(&mut new_root, leaf_value);
-                    self.root = Some(Arc::new(new_root));
-                } else {
-                    let mut root = (*root).clone();
-                    self.insert_non_full(&mut root, leaf_value);
-                    self.root = Some(Arc::new(root));
-                }
-            }
+        } else {
+            let mut root = BNode::new(true);
+            root.entries.push(leaf_value);
+            self.root = Some(Arc::new(root));
         }
     }
 
     fn split_child(&self, parent: &mut BNode<V>, index: usize) {
-        let child = Arc::clone(&parent.children[index]);
+        let (parent_entries, parent_children) = parent.get_mut_parts();
+        let child = Arc::make_mut(&mut parent_children[index]);
         let mut new_child = BNode::new(child.is_leaf);
 
+        // Calculate split points
         let mid = (child.entries.len() - 1) / 2;
-        new_child.entries = child.entries[mid + 1..].to_vec();
-        let middle_entry = child.entries[mid].clone();
-        let mut child = (*child).clone();
-        child.entries.truncate(mid);
-
-        if !child.is_leaf {
-            let mid_child = (child.children.len() + 1) / 2;
-            new_child.children = child.children[mid_child..].to_vec();
-            child.children.truncate(mid_child);
-        }
-
-        parent.entries.insert(index, middle_entry);
-        parent.children[index] = Arc::new(child);
-        parent.children.insert(index + 1, Arc::new(new_child));
-    }
-
-    fn insert_non_full(&self, node: &mut BNode<V>, leaf_value: Arc<LeafValue<V>>) {
-        let mut i = node.entries.len();
-
-        if node.is_leaf {
-            while i > 0
-                && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
-            {
-                i -= 1;
-            }
-            node.entries.insert(i, leaf_value);
+        let mid_child = if child.is_leaf {
+            0
         } else {
-            while i > 0
-                && !self.should_go_right(&node.entries[i - 1], leaf_value.version, leaf_value.ts)
-            {
-                i -= 1;
-            }
+            (child.children.len() + 1) / 2
+        };
 
-            let child = Arc::clone(&node.children[i]);
-            if child.is_full() {
-                self.split_child(node, i);
-                if self.should_go_right(&node.entries[i], leaf_value.version, leaf_value.ts) {
-                    i += 1;
-                }
-            }
-
-            let mut child = (*node.children[i]).clone();
-            self.insert_non_full(&mut child, leaf_value);
-            node.children[i] = Arc::new(child);
+        // Move entries and children in one go
+        new_child.entries = child.entries.split_off(mid + 1);
+        if !child.is_leaf {
+            new_child.children = child.children.split_off(mid_child);
         }
+
+        // Insert middle entry into parent
+        let middle_entry = child.entries.pop().unwrap();
+        parent_entries.insert(index, middle_entry);
+        parent_children.insert(index + 1, Arc::new(new_child));
     }
 
+    #[inline]
     fn should_go_right(&self, entry: &LeafValue<V>, version: u64, ts: u64) -> bool {
         if version != entry.version {
             version > entry.version
         } else {
             ts > entry.ts
         }
+    }
+
+    fn insert_non_full(&self, node: &mut BNode<V>, leaf_value: Arc<LeafValue<V>>) {
+        let mut pos = node.entries.partition_point(|entry| {
+            self.should_go_right(entry, leaf_value.version, leaf_value.ts)
+        });
+
+        if node.is_leaf {
+            node.entries.insert(pos, leaf_value);
+            return;
+        }
+
+        let child = Arc::make_mut(&mut node.children[pos]);
+        if child.is_full() {
+            self.split_child(node, pos);
+            if self.should_go_right(&node.entries[pos], leaf_value.version, leaf_value.ts) {
+                pos += 1;
+            }
+        }
+
+        let child = Arc::make_mut(&mut node.children[pos]);
+        self.insert_non_full(child, leaf_value);
     }
 
     pub fn search(&self, version: u64, ts: u64) -> Option<&Arc<LeafValue<V>>> {
@@ -134,58 +134,25 @@ impl<V: Clone> BTree<V> {
         version: u64,
         ts: u64,
     ) -> Option<&'a Arc<LeafValue<V>>> {
-        let mut i = 0;
+        let pos = node
+            .entries
+            .partition_point(|entry| self.should_go_right(entry, version, ts));
 
-        while i < node.entries.len() && self.should_go_right(&node.entries[i], version, ts) {
-            i += 1;
-        }
-
-        if i < node.entries.len() && version == node.entries[i].version && ts == node.entries[i].ts
+        if pos < node.entries.len()
+            && version == node.entries[pos].version
+            && ts == node.entries[pos].ts
         {
-            Some(&node.entries[i])
+            Some(&node.entries[pos])
         } else if node.is_leaf {
             None
         } else {
-            self.search_node(&node.children[i], version, ts)
+            self.search_node(&node.children[pos], version, ts)
         }
     }
 
-    pub fn last_less_or_equal_ts(&self, ts: u64) -> Option<&Arc<LeafValue<V>>> {
-        let root = self.root.as_ref()?;
-        self.last_less_or_equal_ts_node(root, ts, None)
-    }
-
-    fn last_less_or_equal_ts_node<'a>(
-        &'a self,
-        node: &'a BNode<V>,
-        ts: u64,
-        mut best_so_far: Option<&'a Arc<LeafValue<V>>>,
-    ) -> Option<&'a Arc<LeafValue<V>>> {
-        for entry in &node.entries {
-            if entry.ts <= ts {
-                match best_so_far {
-                    None => best_so_far = Some(entry),
-                    Some(best) if entry.ts > best.ts => best_so_far = Some(entry),
-                    _ => {}
-                }
-            }
-        }
-
-        if !node.is_leaf {
-            for child in &node.children {
-                best_so_far = self.last_less_or_equal_ts_node(child, ts, best_so_far);
-            }
-        }
-
-        best_so_far
-    }
-
-    // Add an iterator that yields Arc<LeafValue<V>> references
-    pub fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_> {
-        match &self.root {
-            None => Box::new(std::iter::empty()),
-            Some(root) => Box::new(BNodeIterator::new(root)),
-        }
+    #[inline]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Arc<LeafValue<V>>> + '_ {
+        BNodeIterator::new(self.root.as_ref())
     }
 
     pub fn clear(&mut self) {
@@ -193,39 +160,44 @@ impl<V: Clone> BTree<V> {
     }
 }
 
-// Iterator for BNode
 struct BNodeIterator<'a, V: Clone> {
-    stack: Vec<(&'a BNode<V>, usize)>,
+    forward_stack: Vec<(&'a BNode<V>, usize)>,
     reverse_stack: Vec<(&'a BNode<V>, usize)>,
 }
 
 impl<'a, V: Clone> BNodeIterator<'a, V> {
-    fn new(root: &'a Arc<BNode<V>>) -> Self {
+    fn new(root: Option<&'a Arc<BNode<V>>>) -> Self {
         let mut iter = BNodeIterator {
-            stack: Vec::new(),
+            forward_stack: Vec::new(),
             reverse_stack: Vec::new(),
         };
-        iter.push_left(root);
-        iter.push_right(root);
+        if let Some(root) = root {
+            iter.push_leftmost(root);
+            iter.push_rightmost(root);
+        }
         iter
     }
 
-    fn push_left(&mut self, node: &'a Arc<BNode<V>>) {
+    fn push_leftmost(&mut self, node: &'a BNode<V>) {
         let mut current = node;
-        while let Some(first_child) = current.children.first() {
-            self.stack.push((current, 0));
-            current = first_child;
+        loop {
+            self.forward_stack.push((current, 0));
+            if current.is_leaf || current.children.is_empty() {
+                break;
+            }
+            current = &current.children[0];
         }
-        self.stack.push((current, 0));
     }
 
-    fn push_right(&mut self, node: &'a Arc<BNode<V>>) {
+    fn push_rightmost(&mut self, node: &'a BNode<V>) {
         let mut current = node;
-        while let Some(last_child) = current.children.last() {
+        loop {
             self.reverse_stack.push((current, current.entries.len()));
-            current = last_child;
+            if current.is_leaf || current.children.is_empty() {
+                break;
+            }
+            current = &current.children[current.children.len() - 1];
         }
-        self.reverse_stack.push((current, current.entries.len()));
     }
 }
 
@@ -233,15 +205,20 @@ impl<'a, V: Clone> Iterator for BNodeIterator<'a, V> {
     type Item = &'a Arc<LeafValue<V>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((node, index)) = self.stack.pop() {
-            if index < node.entries.len() {
-                if index + 1 < node.entries.len() {
-                    self.stack.push((node, index + 1));
-                } else if let Some(next_child) = node.children.get(index + 1) {
-                    self.push_left(next_child);
+        while let Some((node, idx)) = self.forward_stack.last_mut() {
+            if *idx < node.entries.len() {
+                let entry = &node.entries[*idx];
+                *idx += 1;
+
+                if *idx == node.entries.len() && !node.is_leaf {
+                    if let Some(next_child) = node.children.get(*idx) {
+                        self.push_leftmost(next_child);
+                    }
                 }
-                return Some(&node.entries[index]);
+
+                return Some(entry);
             }
+            self.forward_stack.pop();
         }
         None
     }
@@ -249,15 +226,20 @@ impl<'a, V: Clone> Iterator for BNodeIterator<'a, V> {
 
 impl<'a, V: Clone> DoubleEndedIterator for BNodeIterator<'a, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        while let Some((node, index)) = self.reverse_stack.pop() {
-            if index > 0 {
-                if index - 1 > 0 {
-                    self.reverse_stack.push((node, index - 1));
-                } else if let Some(prev_child) = node.children.get(index - 1) {
-                    self.push_right(prev_child);
+        while let Some((node, idx)) = self.reverse_stack.last_mut() {
+            if *idx > 0 {
+                *idx -= 1;
+                let entry = &node.entries[*idx];
+
+                if *idx == 0 && !node.is_leaf {
+                    if let Some(prev_child) = node.children.get(*idx) {
+                        self.push_rightmost(prev_child);
+                    }
                 }
-                return Some(&node.entries[index - 1]);
+
+                return Some(entry);
             }
+            self.reverse_stack.pop();
         }
         None
     }
@@ -289,25 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn test_btree_same_version_different_ts() {
-        let mut tree = BTree::<i32>::new();
-        tree.insert(10, 1, 200);
-        tree.insert(20, 1, 100);
-
-        let result = tree.last_less_or_equal_ts(150);
-        assert_eq!(
-            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((20, 1, 100))
-        );
-
-        let result = tree.last_less_or_equal_ts(300);
-        assert_eq!(
-            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((10, 1, 200))
-        );
-    }
-
-    #[test]
     fn test_btree_full_node_split() {
         let mut tree = BTree::<i32>::new();
         // Insert 2*B entries to force splits
@@ -325,38 +288,6 @@ mod tests {
     }
 
     #[test]
-    fn test_btree_timestamp_queries() {
-        let mut tree = BTree::<i32>::new();
-        tree.insert(10, 1, 100);
-        tree.insert(20, 1, 200);
-        tree.insert(30, 1, 300);
-        tree.insert(40, 1, 400);
-
-        // Test last_less_or_equal_ts
-        assert!(tree.last_less_or_equal_ts(50).is_none());
-        assert_eq!(
-            tree.last_less_or_equal_ts(150)
-                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((10, 1, 100))
-        );
-        assert_eq!(
-            tree.last_less_or_equal_ts(250)
-                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((20, 1, 200))
-        );
-        assert_eq!(
-            tree.last_less_or_equal_ts(350)
-                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((30, 1, 300))
-        );
-        assert_eq!(
-            tree.last_less_or_equal_ts(500)
-                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((40, 1, 400))
-        );
-    }
-
-    #[test]
     fn test_btree_copy_on_write() {
         let mut tree1 = BTree::<i32>::new();
         tree1.insert(10, 1, 100);
@@ -371,50 +302,6 @@ mod tests {
         // New version should be available in tree1
         assert_eq!(tree1.search(1, 100).map(|leaf| leaf.value), Some(10));
         assert_eq!(tree1.search(2, 200).map(|leaf| leaf.value), Some(20));
-    }
-
-    #[test]
-    fn test_btree_decreasing_timestamps() {
-        let mut tree = BTree::<i32>::new();
-        tree.insert(10, 1, 200);
-        tree.insert(20, 2, 100);
-
-        let result = tree.last_less_or_equal_ts(100);
-        assert_eq!(
-            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((20, 2, 100))
-        );
-
-        let result = tree.last_less_or_equal_ts(200);
-        assert_eq!(
-            result.map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((10, 1, 200))
-        );
-    }
-
-    #[test]
-    fn test_btree_large_dataset() {
-        let mut tree = BTree::<i32>::new();
-        for i in 0..1000 {
-            tree.insert(i, i as u64, (i * 2) as u64);
-        }
-
-        // Test random access
-        assert_eq!(tree.search(500, 1000).map(|leaf| leaf.value), Some(500));
-
-        // Test timestamp queries
-        assert_eq!(
-            tree.last_less_or_equal_ts(1500)
-                .map(|leaf| (leaf.value, leaf.version, leaf.ts)),
-            Some((750, 750, 1500))
-        );
-    }
-
-    #[test]
-    fn test_btree_empty() {
-        let tree: BTree<i32> = BTree::new();
-        assert!(tree.search(1, 100).is_none());
-        assert!(tree.last_less_or_equal_ts(100).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Current storage of versions happens using a vector, which slows down dramatically as number of versions increase. This approach uses a btree to help remove dependency on vector