### PR TITLE
Refactor scan iters

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -1592,7 +1592,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     pub fn range<'a, R>(
         &'a self,
         range: R,
-    ) -> impl Iterator<Item = (Vec<u8>, &'a V, &'a u64, &'a u64)>
+    ) -> impl Iterator<Item = (Box<[u8]>, &'a V, &'a u64, &'a u64)>
     where
         R: RangeBounds<P> + 'a,
     {
@@ -1621,7 +1621,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     pub fn range_with_versions<'a, R>(
         &'a self,
         range: R,
-    ) -> impl Iterator<Item = (Vec<u8>, &'a V, &'a u64, &'a u64)>
+    ) -> impl Iterator<Item = (Box<[u8]>, &'a V, &'a u64, &'a u64)>
     where
         R: RangeBounds<P> + 'a,
     {
@@ -2933,7 +2933,7 @@ mod tests {
 
         // Assert that results are in expected order
         for (i, result) in results.iter().enumerate() {
-            let result_str = std::str::from_utf8(result.0.as_slice()).expect("Invalid UTF-8");
+            let result_str = std::str::from_utf8(&result.0).expect("Invalid UTF-8");
             assert_eq!(result_str, expected_order[i]);
         }
     }
@@ -3012,7 +3012,7 @@ mod tests {
             let value = rng.gen_range(1..100);
             let ts = rng.gen_range(1..100);
             tree.insert(&key, value, version, ts).unwrap();
-            inserted_data.push((key.to_slice().to_vec(), value, version, ts));
+            inserted_data.push((Box::from(key.to_slice()), value, version, ts));
         }
 
         // Iteration and verification

--- a/src/art.rs
+++ b/src/art.rs
@@ -1592,7 +1592,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     pub fn range<'a, R>(
         &'a self,
         range: R,
-    ) -> impl Iterator<Item = (Box<[u8]>, &'a V, &'a u64, &'a u64)>
+    ) -> impl Iterator<Item = (&'a [u8], &'a V, &'a u64, &'a u64)>
     where
         R: RangeBounds<P> + 'a,
     {
@@ -1621,7 +1621,7 @@ impl<P: KeyTrait, V: Clone> Tree<P, V> {
     pub fn range_with_versions<'a, R>(
         &'a self,
         range: R,
-    ) -> impl Iterator<Item = (Box<[u8]>, &'a V, &'a u64, &'a u64)>
+    ) -> impl Iterator<Item = (&'a [u8], &'a V, &'a u64, &'a u64)>
     where
         R: RangeBounds<P> + 'a,
     {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -413,7 +413,7 @@ where
 }
 
 impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K, V, R> {
-    type Item = (Box<[u8]>, &'a V, &'a u64, &'a u64);
+    type Item = (&'a [u8], &'a V, &'a u64, &'a u64);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -446,7 +446,7 @@ impl<'a, K: 'a + KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for Range<'a, K
 
         self.forward.leafs.pop_front().map(|leaf| {
             (
-                Box::from(leaf.0.as_slice()),
+                leaf.0.as_slice(),
                 &leaf.1.value,
                 &leaf.1.version,
                 &leaf.1.ts,
@@ -592,7 +592,7 @@ impl<'a, K: KeyTrait, V: Clone, R: RangeBounds<K>> QueryIterator<'a, K, V, R> {
     }
 }
 
-impl<'a, K: KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for QueryIterator<'a, K, V, R> {
+impl<K: KeyTrait, V: Clone, R: RangeBounds<K>> Iterator for QueryIterator<'_, K, V, R> {
     type Item = (Box<[u8]>, Option<V>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1036,13 +1036,13 @@ mod tests {
         let results: Vec<_> = trie.range(range).collect();
 
         let expected = vec![
-            (Box::from(&b"blackberry"[..]), &4, &4, &0),
-            (Box::from(&b"blueberry"[..]), &5, &5, &0),
-            (Box::from(&b"cherry"[..]), &6, &6, &0),
-            (Box::from(&b"date"[..]), &7, &7, &0),
-            (Box::from(&b"fig"[..]), &8, &8, &0),
-            (Box::from(&b"grape"[..]), &9, &9, &0),
-            (Box::from(&b"kiwi"[..]), &10, &10, &0),
+            (&b"blackberry"[..], &4, &4, &0),
+            (&b"blueberry"[..], &5, &5, &0),
+            (&b"cherry"[..], &6, &6, &0),
+            (&b"date"[..], &7, &7, &0),
+            (&b"fig"[..], &8, &8, &0),
+            (&b"grape"[..], &9, &9, &0),
+            (&b"kiwi"[..], &10, &10, &0),
         ];
 
         assert_eq!(results, expected);
@@ -1082,13 +1082,10 @@ mod tests {
         let btree_range = Box::from(&b"berry"[..])..=Box::from(&b"kiwi"[..]);
         let btree_results: Vec<_> = btree
             .range(btree_range)
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (k.as_ref(), *v))
             .collect();
 
-        let trie_expected: Vec<_> = trie_results
-            .iter()
-            .map(|(k, v, _, _)| (k.clone(), **v))
-            .collect();
+        let trie_expected: Vec<_> = trie_results.iter().map(|(k, v, _, _)| (*k, **v)).collect();
 
         assert_eq!(trie_expected, btree_results);
     }


### PR DESCRIPTION
## Description

This PR does the following:

1. Make iterators return &[u8] instead of vector.

2. Current methods like `scan_node` and `query_keys_at_node` return computed results which make it difficult to implement any sort of logic with limit functionality on surrealkv. This change makes these methods return an iterator, which could lead to better performance