### PR TITLE
remove: keys_at_ts

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -536,19 +536,6 @@ where
     QueryIterator::new(node, range, query_type)
 }
 
-pub(crate) fn query_keys_at_node<'a, K, V, R>(
-    node: Option<&'a Arc<Node<K, V>>>,
-    range: R,
-    query_type: QueryType,
-) -> impl Iterator<Item = &'a [u8]> + 'a
-where
-    K: KeyTrait + 'a,
-    V: Clone,
-    R: RangeBounds<K> + 'a,
-{
-    QueryIterator::new(node, range, query_type).map(|(k, _, _, _)| k)
-}
-
 pub(crate) struct QueryIterator<'a, K: KeyTrait, V: Clone, R: RangeBounds<K>> {
     forward: ForwardIterState<'a, K, V>,
     prefix: Vec<u8>,


### PR DESCRIPTION
## Description

This PR removes `keys_at_ts` function because scan_at_ts iterator can be reused to filter out for only keys. This avoids having repeated code for the same functionality